### PR TITLE
Add contributing documents

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,56 @@
+# Contributing to move.mil
+
+Anyone is welcome to contribute code changes and additions to this project. If you'd like your changes merged into the master branch, please read the following document before opening a [pull request][pulls].
+
+There are several ways in which you can help improve this project:
+
+1. Fix an existing [issue][issues] and submit a [pull request][pulls].
+1. Review open [pull requests][pulls].
+1. Report a new [issue][issues]. _Only do this after you've made sure the behavior or problem you're observing isn't already documented in an open issue._
+
+## Getting started
+
+move.mil is a static website built using [Jekyll](http://jekyllrb.com/), a popular static site generator written in [Ruby](https://www.ruby-lang.org/). Development dependencies are managed using the [Bundler](http://bundler.io/) gem.
+
+This project uses Ruby version 2.3.3 which can be installed using a Ruby version manager like [rbenv](https://github.com/rbenv/rbenv) (macOS, Linux) or a package manager like [Chocolatey](https://chocolatey.org/) (Windows). The Jekyll documentation website has additional instructions for [using Ruby and Jekyll on Windows platforms](https://jekyllrb.com/docs/windows/).
+
+Once you've installed Ruby 2.3.3 using the method most appropriate to your environment, install the Bundler gem:
+
+```sh
+gem install bundler
+```
+
+After successfully installing Bundler, run the following command from the root of the project to install the dependencies specified in the [Gemfile][gemfile]:
+
+```sh
+bundle install
+```
+
+## Making changes
+
+1. Fork and clone the project's repo.
+1. Install development dependencies as outlined above.
+1. Create a feature branch for the code changes you're looking to make: `git checkout -b your-descriptive-branch-name origin/master`.
+1. _Write some code!_
+1. Build the site and verify that your changes function as intended: `bundle exec rake jekyll:build`.
+1. Commit your changes: `git commit -am 'Add some new feature or fix some issue'`.
+1. Push the branch to your fork: `git push -u origin your-descriptive-branch-name`.
+1. Create a new pull request and we'll review your changes.
+
+## Code Style
+
+Code formatting conventions are defined in the `.editorconfig` file which uses the [EditorConfig](http://editorconfig.org/) syntax. There are [plugins for a variety of editors](http://editorconfig.org/#download) that utilize the settings in the `.editorconfig` file. It is recommended that you install EditorConfig plugin for your editor of choice.
+
+Your bug fix or feature addition won't be rejected if it runs afoul of any (or all) of these guidelines, but following the guidelines will definitely make everyone's lives a little easier.
+
+## Legalese
+
+Before submitting a pull request to this repository for the first time, you'll need to sign a [Developer Certificate of Origin](https://developercertificate.org/) (DCO). To read and agree to the DCO, you'll add your name and email address to [CONTRIBUTORS.md][contributors]. At a high level, this tells us that you have the right to submit the work you're contributing in your pull request and says that you consent to us treating the contribution in a way consistent with the license associated with this software (as described in [LICENSE][license]) and its documentation ("Project").
+
+You may submit contributions anonymously or under a pseudonym if you'd like, but we need to be able to reach you at the email address you provide when agreeing to the DCO. Contributions you make to this public Department of Defense repository are completely voluntary. When you submit a pull request, you're offering your contribution without expectation of payment and you expressly waive any future pay claims against the U.S. Federal Government related to your contribution.
+
+[contributors]: https://github.com/deptofdefense/move.mil/blob/master/CONTRIBUTORS.md
+[gemfile]: https://github.com/deptofdefense/move.mil/blob/master/Gemfile
+[issues]: https://github.com/deptofdefense/move.mil/issues
+[license]: https://github.com/deptofdefense/move.mil/blob/master/LICENSE
+[pulls]: https://github.com/deptofdefense/move.mil/pulls

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,14 @@
+# Contributors
+
+**By adding your name, email address, and copyright date below, you understand and agree to the terms of the [Developer's Certificate of Origin](https://developercertificate.org/) (DCO) version 1.1, and you are submitting all contributions you make to this Project pursuant to the terms described in [LICENSE][license].**
+
+## Signed-off-by
+
+- Copyright 2017 U.S. Federal Government (in countries where recognized) contact@dds.mil
+- _Add the copyright date, your name, and email address here._
+
+## Note for U.S. Federal Employees
+
+If you're a U.S. Federal Government employee and use a `*.mil` or `*.gov` email address to agree to the DCO, we interpret your signed DCO to mean that the contribution was created in whole or in part by you as part of your job with the U.S. Federal Government and that your contribution is not subject to copyright protections.
+
+[license]: https://github.com/deptofdefense/move.mil/blob/master/LICENSE

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,7 @@
+Copyright 2017 U.S. Federal Government (in countries where recognized)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # move.mil
+
+This repository contains the source code for the [move.mil](http://www.move.mil/) website, the official portal to the Defense Personal Property System (DPS). DPS is an online system managed by the U.S. [Department of Defense](https://www.defense.gov/) (DoD) [Transportation Command](http://www.ustranscom.mil/) (USTRANSCOM) and is used by service members and their families to manage household goods moves.
+
+This version of move.mil was built by a [Defense Digital Service](https://www.dds.mil/) team in support of USTRANSCOM's mission. This website's source code is made available to the open source community with the hope that community contributions will improve functionality, add features, and mature this work.
+
+## Contributing
+
+For details on setting up your development environment and contributing to this project, see [CONTRIBUTING.md][contributing].
+
+## License
+
+As part of the Defense Digital Service's goal of bringing technology industry practices to the U.S. Department of Defense, we welcome contributions to this repository from the open source community. If you are interested in contributing to this project, please review [CONTRIBUTING.md][contributing] and [LICENSE][license]. Those files describe how to contribute to this work. A list of contributors to this project is maintained in [CONTRIBUTORS.md][contributors].
+
+Works created by U.S. Federal employees as part of their jobs typically are not eligible for copyright in the United States. In places where the contributions of U.S. Federal employees are not eligible for copyright, this work is in the public domain. In places where it is eligible for copyright, such as some foreign jurisdictions, this work is licensed as described in [LICENSE][license].
+
+[contributing]: https://github.com/deptofdefense/move.mil/blob/master/CONTRIBUTING.md
+[contributors]: https://github.com/deptofdefense/move.mil/blob/master/CONTRIBUTORS.md
+[license]: https://github.com/deptofdefense/move.mil/blob/master/LICENSE


### PR DESCRIPTION
This PR adds several contributing-related documents to the project and updates the README. Much of the content in the contributing documents is adapted from the [ANET repository](https://github.com/deptofdefense/anet).