### PR TITLE
Add GitHub issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,29 @@
+Thanks for submitting an issue! Below are a few things you can do to help us more quickly address the issue.
+
+## Checklist
+
+I have…
+
+- [ ] described in detail below both the behavior I expected and the behavior I observed.
+- [ ] thoroughly outlined below the steps to reproduce this issue, including relevant technical details (e.g. device, operating system, browser, browser version).
+- [ ] attached screenshots illustrating relevant behavior.
+
+## Expected Behavior
+
+_Summarize expected behavior._
+
+## Observed Behavior
+
+_Summarize observed behavior._
+
+## Steps to Reproduce
+
+To reproduce this issue…
+
+1. _Describe step one._
+1. _Describe step two._
+1. _etc. etc. etc._
+
+## Screenshots
+
+_Attach relevant screenshots here._

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+Thanks for submitting a pull request! Below are a few things you can do to help us more quickly review your changes.
+
+## Checklist
+
+I have…
+
+- [ ] built and served the site locally (`bundle exec rake jekyll:serve`) and verified that my changes behave as expected.
+- [ ] run the test suite (`bundle exec rake`) and verified that all tests pass.
+- [ ] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
+- [ ] thoroughly outlined below the steps necessary to test my changes.
+- [ ] attached screenshots illustrating relevant behavior before and after my changes.
+- [ ] read, understand, and agree to the terms described in [CONTRIBUTING.md](https://github.com/deptofdefense/move.mil/blob/master/CONTRIBUTING.md).
+- [ ] added my name, email address, and copyright date to [CONTRIBUTORS.md](https://github.com/deptofdefense/move.mil/blob/master/CONTRIBUTORS.md).
+
+## Summary of Changes
+
+This pull request…
+
+- _Summarize change number one._
+- _Summarize change number two._
+- _etc. etc. etc._
+
+## Testing
+
+To verify the changes proposed in this pull request…
+
+1. _Describe testing step one._
+1. _Describe testing step two._
+1. _etc. etc. etc._
+
+## Screenshots
+
+_Attach relevant before and after screenshots here._


### PR DESCRIPTION
This PR adds GitHub issue and pull request templates.

Useful background on these files:

- [Issue and Pull Request templates](https://github.com/blog/2111-issue-and-pull-request-templates) (blog post)
- [Creating an issue template for your repository](https://help.github.com/articles/creating-an-issue-template-for-your-repository/) (documentation)
- [Creating a pull request template for your repository](https://help.github.com/articles/creating-a-pull-request-template-for-your-repository/) (documentation)