### PR TITLE
Add Jekyll "release" Rake task

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,9 +51,10 @@ bundle install
 There are a number of useful [Rake](https://github.com/ruby/rake) tasks that make working with the project easier. From the root of the project, run `bundle exec rake -T` for a list of available commands.
 
 ```sh
-rake htmlproofer   # Test the site with html-proofer
-rake jekyll:build  # Build the site to `./public`
-rake jekyll:serve  # Serve the site at `http://localhost:4000`
+rake htmlproofer     # Test the site with html-proofer
+rake jekyll:build    # Build the site to `./public`
+rake jekyll:release  # Build the production-ready site to `./public`
+rake jekyll:serve    # Serve the site at `http://localhost:4000`
 ```
 
 The most useful of these tasks, `bundle exec rake jekyll:serve`, will build and serve the site from the `./public` folder, regenerating the site as changes are made to files in the `./src` folder. Changes may be previewed in a Web browser at [http://localhost:4000](http://localhost:4000). Depending on your local development environment, you may need to try `localhost:4000` or `127.0.0.1:4000`.

--- a/lib/tasks/jekyll.rake
+++ b/lib/tasks/jekyll.rake
@@ -4,6 +4,11 @@ namespace :jekyll do
     sh 'bundle exec jekyll build --config config/jekyll.yml --trace'
   end
 
+  desc 'Build the production-ready site to `./public`'
+  task :release do
+    sh 'JEKYLL_ENV=production bundle exec jekyll build --config config/jekyll.yml --trace'
+  end
+
   desc 'Serve the site at `http://localhost:4000`'
   task :serve do
     sh 'bundle exec jekyll serve --config config/jekyll.yml --trace'


### PR DESCRIPTION
## Checklist

I have…

- [x] built and served the site locally (`bundle exec rake jekyll:serve`) and verified that my changes behave as expected.
- [x] run the test suite (`bundle exec rake`) and verified that all tests pass.
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.

## Summary of Changes

This pull request…

- adds a new Rake task (`rake jekyll:release`) that prepares a production-ready version of the site, and
- adds that task to `CONTRIBUTING.md`.

## Testing

To verify the changes proposed in this pull request…

1. Clone this repo and set up development dependencies.
1. `git checkout add-jekyll-release-task`
1. `bundle exec rake jekyll:release`
1. Inspect the source files in `./public`, noting that CSS and JS assets are properly minified and that those assets are linked to from HTML files.
