### PR TITLE
Update site header markup and styling

### DIFF
--- a/src/_assets/stylesheets/application.scss
+++ b/src/_assets/stylesheets/application.scss
@@ -50,5 +50,7 @@ $asset-pipeline: true;
 @import "uswds/components/skipnav";
 
 // Site -------------- //
-@import "elements/*";
-@import "components/*";
+@import "elements/typography";
+@import "components/footer";
+@import "components/header";
+@import "components/navigation";

--- a/src/_assets/stylesheets/components/_header.scss
+++ b/src/_assets/stylesheets/components/_header.scss
@@ -1,0 +1,29 @@
+.usa-header-extended em {
+  font-family: $font-serif;
+  font-size: $h2-font-size;
+
+  @include media($nav-width) {
+    font-size: $title-font-size;
+  }
+}
+
+.usa-logo {
+  a {
+    display: inline-block;
+  }
+
+  br {
+    display: inline;
+  }
+}
+
+.usa-logo-text span {
+  display: none;
+  font-family: $font-sans;
+  font-size: $h2-font-size;
+  font-weight: $font-normal;
+
+  @include media($nav-width) {
+    display: block;
+  }
+}

--- a/src/_assets/stylesheets/components/_navigation.scss
+++ b/src/_assets/stylesheets/components/_navigation.scss
@@ -1,0 +1,35 @@
+.usa-navbar {
+  @include padding(1rem 0);
+  height: 6rem;
+
+  @include media($nav-width) {
+    @include padding(0 null);
+  }
+
+  .usa-media_block {
+    display: table;
+
+    @include media($nav-width) {
+      line-height: 1;
+    }
+
+    .usa-media_block-img {
+      display: none;
+      max-width: 14rem;
+      margin-right: 2rem;
+
+      @include media($nav-width) {
+        display: table-cell;
+      }
+
+      img {
+        width: 100%;
+      }
+    }
+
+    .usa-media_block-body {
+      display: table-cell;
+      vertical-align: middle;
+    }
+  }
+}

--- a/src/_layouts/application.html
+++ b/src/_layouts/application.html
@@ -46,10 +46,19 @@
     <div class="usa-navbar">
       <button class="usa-menu-btn">Menu</button>
 
-      <div class="usa-logo" id="logo">
-        <em class="usa-logo-text">
-          <a href="/" aria-label="Home" rel="home" title="Home">Move.mil</a>
-        </em>
+      <div class="usa-logo usa-media_block" id="logo">
+        <a href="http://www.ustranscom.mil" class="usa-media_block-img">
+          <img src="{% asset_path ustranscom-emblem.svg %}" alt="USTRANSCOM emblem">
+        </a>
+        <div class="usa-media_block-body">
+          <em class="usa-logo-text">
+            <a href="/" aria-label="Home" rel="home" title="Home">
+              Move.mil
+              <br>
+              <span>Official <abbr title="Department of Defense">DOD</abbr> Moving Portal</span>
+            </a>
+          </em>
+        </div>
       </div>
     </div>
 
@@ -75,7 +84,7 @@
           </li>
           <li>
             <a href="http://www.move.mil/ppso/ppso_resources/dps_login_solution.cfm" class="usa-nav-link">
-              <span>For PPSO Offices</span>
+              <span>For <abbr title="Personal Property Shipping Office">PPSO</abbr> Offices</span>
             </a>
           </li>
         </ul>


### PR DESCRIPTION
Thanks for submitting a pull request! Below are a few things you can do to help us more quickly review your changes.

## Checklist

I have…

- [x] built and served the site locally (`bundle exec rake jekyll:serve`) and verified that my changes behave as expected.
- [x] run the test suite (`bundle exec rake`) and verified that all tests pass.
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.

## Summary of Changes

This pull request…

- adds the USTRANSCOM emblem to the site header,
- adds markup to the site header to support the USTRANSCOM logo and sub-header, and
- adds styling to support use of [the US Web Design Standards'](https://github.com/18F/web-design-standards) media block element in the site header.

## Testing

To verify the changes proposed in this pull request…

1. clone this repo and set up development dependencies,
1. `git checkout add-site-navigation`,
1. `bundle exec rake jekyll:serve`,
1. point your Web browser of choice at http://localhost:4000, and
1. observe that the site renders and behaves as shown in the screenshots below.

## Screenshots

### Narrow viewport

![narrow](https://cloud.githubusercontent.com/assets/27780860/25813864/24508802-33e9-11e7-8ca0-8d13f7d14839.png)

### Wide viewport

![wide](https://cloud.githubusercontent.com/assets/27780860/25813866/2816719a-33e9-11e7-8589-b92b3ad0caef.png)