### PR TITLE
First draft of “Schedule Your Move”, still missing iconography

### DIFF
--- a/lib/rake/tasks/htmlproofer.rake
+++ b/lib/rake/tasks/htmlproofer.rake
@@ -2,5 +2,10 @@ require 'html-proofer'
 
 desc 'Test the site with html-proofer'
 task :htmlproofer do
-  HTMLProofer.check_directory('./public', { assume_extension: true }).run
+  options = {
+    assume_extension: true,
+    empty_alt_ignore: true
+  }
+
+  HTMLProofer.check_directory('./public', options).run
 end

--- a/src/_assets/stylesheets/components/_layout.scss
+++ b/src/_assets/stylesheets/components/_layout.scss
@@ -58,3 +58,20 @@
     margin-top: 1rem;
   }
 }
+
+.your-moving-toolkit {
+  margin-top: $site-margins;
+  padding: 0;
+
+  h3 {
+    font-family: $font-sans;
+    text-align: center;
+  }
+
+  span {
+    display: block;
+    font-size: $h5-font-size;
+    font-weight: $font-normal;
+    margin-top: 1rem;
+  }
+}

--- a/src/_assets/stylesheets/components/_layout.scss
+++ b/src/_assets/stylesheets/components/_layout.scss
@@ -42,28 +42,13 @@
   }
 }
 
-.conus-vs-oconus-moves {
-  margin-top: $site-margins;
-  padding: 0;
-
-  h3 {
-    font-family: $font-sans;
-    text-align: center;
-  }
-
-  span {
-    display: block;
-    font-size: $h5-font-size;
-    font-weight: $font-normal;
-    margin-top: 1rem;
-  }
-}
-
+.conus-vs-oconus-moves,
 .your-moving-toolkit {
   margin-top: $site-margins;
   padding: 0;
 
   h3 {
+    color: $color-primary-darkest;
     font-family: $font-sans;
     text-align: center;
   }

--- a/src/_assets/stylesheets/elements/_typography.scss
+++ b/src/_assets/stylesheets/elements/_typography.scss
@@ -5,4 +5,19 @@ abbr[title] {
 .homepage-content-title {
   border-bottom: 0.25rem solid $color-black;
   padding-bottom: 0.5rem;
+
+.divider-heading {
+  border-top: 4px solid #112e51;
+
+  span {
+    background-color: #112e51;
+    color: #fff;
+    display: inline-block;
+    font-family: $font-serif;
+    font-size: $h6-font-size;
+    font-style: italic;
+    font-weight: bold;
+    padding: 0.5rem 3rem;
+    text-align: center;
+  }
 }

--- a/src/_assets/stylesheets/elements/_typography.scss
+++ b/src/_assets/stylesheets/elements/_typography.scss
@@ -8,17 +8,19 @@ abbr[title] {
 }
 
 .divider-heading {
-  border-top: 4px solid #112e51;
+  border-top: 0.25rem solid $color-primary-darkest;
+  overflow: hidden;
 
   span {
-    background-color: #112e51;
-    color: #fff;
-    display: inline-block;
+    @include padding(0.5rem $site-margins 0.75rem);
+    background-color: $color-primary-darkest;
+    color: $color-white;
+    display: block;
+    float: left;
     font-family: $font-serif;
     font-size: $h6-font-size;
     font-style: italic;
     font-weight: bold;
-    padding: 0.5rem 3rem;
     text-align: center;
   }
 }

--- a/src/_assets/stylesheets/elements/_typography.scss
+++ b/src/_assets/stylesheets/elements/_typography.scss
@@ -5,6 +5,7 @@ abbr[title] {
 .homepage-content-title {
   border-bottom: 0.25rem solid $color-black;
   padding-bottom: 0.5rem;
+}
 
 .divider-heading {
   border-top: 4px solid #112e51;

--- a/src/_data/navigation.yml
+++ b/src/_data/navigation.yml
@@ -11,6 +11,16 @@
 - title: Schedule Your Move
   url: /schedule-your-move
 
+  subnav:
+    - title: Access DPS via ETA
+      url: /access-dps-via-eta
+
+    - title: Learn how to use DPS
+      url: /learn-how-to-use-dps
+
+    - title: Estimate Weight Allowance
+      url: /estimate-weight-allowance
+
 - title: File and Manage Claims
   url: /claims
 

--- a/src/_data/navigation.yml
+++ b/src/_data/navigation.yml
@@ -15,7 +15,7 @@
     - title: Access DPS via ETA
       url: /access-dps-via-eta
 
-    - title: Learn how to use DPS
+    - title: Learn How to Use DPS
       url: /learn-how-to-use-dps
 
     - title: Estimate Weight Allowance

--- a/src/schedule-your-move/access-dps-via-eta/index.html
+++ b/src/schedule-your-move/access-dps-via-eta/index.html
@@ -1,0 +1,4 @@
+---
+layout: page
+title: Access DPS via ETA
+---

--- a/src/schedule-your-move/estimate-weight-allowance/index.html
+++ b/src/schedule-your-move/estimate-weight-allowance/index.html
@@ -1,0 +1,4 @@
+---
+layout: page
+title: Estimate Weight Allowance
+---

--- a/src/schedule-your-move/index.html
+++ b/src/schedule-your-move/index.html
@@ -3,63 +3,36 @@ layout: page
 title: Schedule Your Move
 ---
 
-<p>
-    Counseling is a requirement for any government move. In the past this would
-    have been accomplished by making an appointment at your local
-    counseling/transportation office and sitting with a personal property
-    counselor. That was a very important process, as the counselor could
-    explain all of your government entitlements (moves, storage, etc). They
-    could also review the responsibilities of you, the customer, and the
-    responsibilities of your assigned TSP (transportation service provider).
-    With the release of DPS, you now have two options on how you complete your
-    counseling process.
-</p>
+<p>Counseling is a requirement for any government move. In the past this would have been accomplished by making an appointment at your local counseling/transportation office and sitting with a personal property counselor. That was a very important process, as the counselor could explain all of your government entitlements (moves, storage, etc). They could also review the responsibilities of you, the customer, and the responsibilities of your assigned TSP (transportation service provider). With the release of DPS, you now have two options on how you complete your counseling process.</p>
+<p>You can still make an appointment at your local counseling/transportation office and sit with a personal property counselor to set up your move. Alternatively, you can log into DPS and perform an online selfcounseling. DPS will review your entitlements with you and walk you through the process of setting up your move.</p>
 
-<p>
-    You can still make an appointment at your local counseling/transportation
-    office and sit with a personal property counselor to set up your move.
-    Alternatively, you can log into DPS and perform an online selfcounseling.
-    DPS will review your entitlements with you and walk you through the process
-    of setting up your move.
-</p>
+<h2 class="divider-heading"><span>Your Moving Toolkit</span></h2>
 
-<div class="Line"></div>
-
-<h6 class="divider-heading"><span>Your Moving Toolkit</span></h6>
 <div class="usa-grid your-moving-toolkit">
-    <div class="usa-width-one-third">
-        <h3>
-            <abbr title="Electronic Transportation Acquisition">ETA</abbr> Portal
-            <span>eta.sddc.army.mil</span>
-        </h3>
-
-        <p>
-            Logging into DPS is managed by the Electronic Transporation Acquisition
-            (ETA) Portal. <abbr title="Electronic Transportation Acquisition">ETA</abbr>
-            is managed by the Army <abbr title="Surface Deployment and Distribution">SDDC</abbr>
-            team.
-        </p>
-        <p><a href="access-dps-via-eta">Learn how to login to <abbr title="Electronic Transportation Acquisition">ETA</abbr></a></p>
-        <p><a href="learn-how-to-use-dps">Troubleshooting your <abbr title="Electronic Transportation Acquisition">ETA</abbr> login</a></p>
-    </div>
-    <div class="usa-width-one-third">  
-        <h3>Find your Local Counseling Office</h3>
-        
-        <p>
-            Find your local conseling office if self-conseling is not an
-            option, or if your service-specific requirements indicate you
-            can’t use <abbr title="Defense Personal Property System">DPS</abbr>.
-        </p>
-        <p><a href="https://www.move.mil/common/locator_maps/trans_offices_pjf.cfm">Find your local counseling office</a></p>
-  </div>
   <div class="usa-width-one-third">
-      <h3>Weight Calculator</h3>
+    <h3>
+      <abbr title="Electronic Transportation Acquisition">ETA</abbr> Portal
+      <span>eta.sddc.army.mil</span>
+    </h3>
 
-      <p>
-          You have a certain weight allowance depending on your service, rank, and family situation. We can help you figure out how much you have, so you can have the best estimate ready for your move.
-      </p>
-      <p><a href="estimate-weight-allowance">Calculate my weight allowance!</a></p>
-      <p><a href="/service-specific-information">Service-specific entitlement information</a></p>
+    <p>Logging into DPS is managed by the Electronic Transporation Acquisition (ETA) Portal. <abbr title="Electronic Transportation Acquisition">ETA</abbr> is managed by the Army <abbr title="Surface Deployment and Distribution Command">SDDC</abbr> team.</p>
+    <p><a href="/schedule-your-move/access-dps-via-eta">Learn how to login to <abbr title="Electronic Transportation Acquisition">ETA</abbr></a></p>
+    <p><a href="/schedule-your-move/learn-how-to-use-dps">Troubleshooting your <abbr title="Electronic Transportation Acquisition">ETA</abbr> login</a></p>
+  </div>
+
+  <div class="usa-width-one-third">
+    <h3>Find your Local Counseling Office</h3>
+
+    <p>Find your local conseling office if self-conseling is not an option, or if your service-specific requirements indicate you can’t use <abbr title="Defense Personal Property System">DPS</abbr>.</p>
+    <p><a href="https://www.move.mil/common/locator_maps/trans_offices_pjf.cfm">Find your local counseling office</a></p>
+  </div>
+
+  <div class="usa-width-one-third">
+    <h3>Weight Calculator</h3>
+
+    <p>You have a certain weight allowance depending on your service, rank, and family situation. We can help you figure out how much you have, so you can have the best estimate ready for your move.</p>
+    <p><a href="/schedule-your-move/estimate-weight-allowance">Calculate your weight allowance</a></p>
+    <p><a href="/service-specific-information">Service-specific entitlement information</a></p>
   </div>
 
 </div>

--- a/src/schedule-your-move/index.html
+++ b/src/schedule-your-move/index.html
@@ -2,3 +2,64 @@
 layout: page
 title: Schedule Your Move
 ---
+
+<p>
+    Counseling is a requirement for any government move. In the past this would
+    have been accomplished by making an appointment at your local
+    counseling/transportation office and sitting with a personal property
+    counselor. That was a very important process, as the counselor could
+    explain all of your government entitlements (moves, storage, etc). They
+    could also review the responsibilities of you, the customer, and the
+    responsibilities of your assigned TSP (transportation service provider).
+    With the release of DPS, you now have two options on how you complete your
+    counseling process.
+</p>
+
+<p>
+    You can still make an appointment at your local counseling/transportation
+    office and sit with a personal property counselor to set up your move.
+    Alternatively, you can log into DPS and perform an online selfcounseling.
+    DPS will review your entitlements with you and walk you through the process
+    of setting up your move.
+</p>
+
+<div class="Line"></div>
+
+<h6 class="divider-heading"><span>Your Moving Toolkit</span></h6>
+<div class="usa-grid your-moving-toolkit">
+    <div class="usa-width-one-third">
+        <h3>
+            <abbr title="Electronic Transportation Acquisition">ETA</abbr> Portal
+            <span>eta.sddc.army.mil</span>
+        </h3>
+
+        <p>
+            Logging into DPS is managed by the Electronic Transporation Acquisition
+            (ETA) Portal. <abbr title="Electronic Transportation Acquisition">ETA</abbr>
+            is managed by the Army <abbr title="Surface Deployment and Distribution">SDDC</abbr>
+            team.
+        </p>
+        <p><a href="access-dps-via-eta">Learn how to login to <abbr title="Electronic Transportation Acquisition">ETA</abbr></a></p>
+        <p><a href="learn-how-to-use-dps">Troubleshooting your <abbr title="Electronic Transportation Acquisition">ETA</abbr> login</a></p>
+    </div>
+    <div class="usa-width-one-third">  
+        <h3>Find your Local Counseling Office</h3>
+        
+        <p>
+            Find your local conseling office if self-conseling is not an
+            option, or if your service-specific requirements indicate you
+            can’t use <abbr title="Defense Personal Property System">DPS</abbr>.
+        </p>
+        <p><a href="https://www.move.mil/common/locator_maps/trans_offices_pjf.cfm">Find your local counseling office</a></p>
+  </div>
+  <div class="usa-width-one-third">
+      <h3>Weight Calculator</h3>
+
+      <p>
+          You have a certain weight allowance depending on your service, rank, and family situation. We can help you figure out how much you have, so you can have the best estimate ready for your move.
+      </p>
+      <p><a href="estimate-weight-allowance">Calculate my weight allowance!</a></p>
+      <p><a href="/service-specific-information">Service-specific entitlement information</a></p>
+  </div>
+
+</div>

--- a/src/schedule-your-move/learn-how-to-use-dps/index.html
+++ b/src/schedule-your-move/learn-how-to-use-dps/index.html
@@ -1,4 +1,4 @@
 ---
 layout: page
-title: Learn how to use DPS
+title: Learn How to Use DPS
 ---

--- a/src/schedule-your-move/learn-how-to-use-dps/index.html
+++ b/src/schedule-your-move/learn-how-to-use-dps/index.html
@@ -1,0 +1,4 @@
+---
+layout: page
+title: Learn how to use DPS
+---


### PR DESCRIPTION
## Checklist

I have…

- [x] built and served the site locally (`bundle exec rake jekyll:serve`) and verified that my changes behave as expected.
- [x] run the test suite (`bundle exec rake`) and verified that all tests pass.
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.
- [x] read, understand, and agree to the terms described in [CONTRIBUTING.md](https://github.com/deptofdefense/move.mil/blob/master/CONTRIBUTING.md).
- [x] added my name, email address, and copyright date to [CONTRIBUTORS.md](https://github.com/deptofdefense/move.mil/blob/master/CONTRIBUTORS.md).

## Summary of Changes

- Added content to the "Schedule Your Move" page
- Implemented the "divider-heading" class used here as well as on other pages
- Added stubs for the subpages of Schedule Your Move
- Updated the subnavigation

## Testing

1. Loaded the page in Chrome, Firefox, and Safari and verified that the layout looks right.
1. Tested each of the links on the page.
1. Tested each of the subnavigation entries.

## Screenshots

Before:

![fireshot capture 31 - move mil schedule your move - http___localhost_4000_schedule-your-move_](https://cloud.githubusercontent.com/assets/26554826/26178668/e7e6f868-3b24-11e7-9960-bb8c780e985c.png)

After:

![fireshot capture 30 - move mil schedule your move - http___localhost_4000_schedule-your-move_](https://cloud.githubusercontent.com/assets/26554826/26178828/a5c36bc8-3b25-11e7-8a7e-31d6115b7505.png)
