### PR TITLE
Additional enhancements to "Determine Your Moving Allowance" page

### DIFF
--- a/src/_assets/javascripts/components/moving-allowances-table.js
+++ b/src/_assets/javascripts/components/moving-allowances-table.js
@@ -6,6 +6,15 @@
 
     $window.on('update', this.events.update.bind(this));
 
+    this.$el.find('.view-details').each(function() {
+      var $clone = $(this.hash).clone();
+
+      $clone.find('h4, .return-to-moving-allowances').remove();
+      $clone.removeAttr('id').insertAfter($(this));
+    });
+
+    this.$el.addClass('moving-allowances-table-enhanced');
+
     this.toggle(true);
   };
 
@@ -13,6 +22,11 @@
     events: {
       update: function(event, data) {
         this.toggle(data.payGrade !== this.$el.data('payGrade'));
+
+        this.$el.attr({
+          'data-dependency-status': data.dependencyStatus,
+          'data-move-type': data.moveType
+        });
       }
     },
 

--- a/src/_assets/javascripts/components/moving-allowances.js
+++ b/src/_assets/javascripts/components/moving-allowances.js
@@ -13,6 +13,8 @@
     });
 
     $window.on('update', this.events.update.bind(this));
+
+    this.$el.addClass('moving-allowances-section-enhanced');
   };
 
   MovingAllowances.prototype = {

--- a/src/_assets/stylesheets/application.scss
+++ b/src/_assets/stylesheets/application.scss
@@ -9,6 +9,10 @@ $image-path: "uswds";
 // Set $asset-pipeline to true if you're using the Rails Asset Pipeline
 $asset-pipeline: true;
 
+// Site variables -------------- //
+
+$moving-allowances-wide: 950px;
+
 // Vendor -------------- //
 @import "bourbon";
 @import "neat";

--- a/src/_assets/stylesheets/components/_section.scss
+++ b/src/_assets/stylesheets/components/_section.scss
@@ -41,6 +41,12 @@
   }
 }
 
+@include media($moving-allowances-wide) {
+  .moving-allowances-section-enhanced + .moving-allowances-tips-section {
+    display: none;
+  }
+}
+
 .faq-section {
   h2 {
     font-size: $h3-font-size;

--- a/src/_assets/stylesheets/elements/_table.scss
+++ b/src/_assets/stylesheets/elements/_table.scss
@@ -30,13 +30,14 @@ table {
 
 .moving-allowances-table-enhanced {
   &[data-dependency-status="false"] {
-    [data-allowance-type="self-plus-dependents"] {
+    [data-allowance-key="total_weight_self_plus_dependents"],
+    [data-allowance-key="pro_gear_spouse"] {
       display: none;
     }
   }
 
   &[data-dependency-status="true"] {
-    [data-allowance-type="self"] {
+    [data-allowance-key="total_weight_self"] {
       display: none;
     }
   }

--- a/src/_assets/stylesheets/elements/_table.scss
+++ b/src/_assets/stylesheets/elements/_table.scss
@@ -27,3 +27,49 @@ table {
     }
   }
 }
+
+.moving-allowances-table-enhanced {
+  &[data\-dependency\-status="false"] {
+    [data\-allowance\-type="self-plus-dependents"] {
+      display: none;
+    }
+  }
+
+  &[data\-dependency\-status="true"] {
+    [data\-allowance\-type="self"] {
+      display: none;
+    }
+  }
+
+  &[data\-move\-type="conus"] {
+    .oconus-details,
+    .conus-details h5 {
+      display: none;
+    }
+  }
+
+  &[data\-move\-type="oconus"] {
+    .conus-details,
+    .oconus-details h5 {
+      display: none;
+    }
+  }
+
+  @include media($moving-allowances-wide) {
+    .view-details {
+      display: none;
+    }
+  }
+
+  .moving-allowances-tips {
+    display: none;
+
+    @include media($moving-allowances-wide) {
+      display: block;
+    }
+
+    > :first-child > :first-child {
+      margin-top: 0;
+    }
+  }
+}

--- a/src/_assets/stylesheets/elements/_table.scss
+++ b/src/_assets/stylesheets/elements/_table.scss
@@ -29,26 +29,26 @@ table {
 }
 
 .moving-allowances-table-enhanced {
-  &[data\-dependency\-status="false"] {
-    [data\-allowance\-type="self-plus-dependents"] {
+  &[data-dependency-status="false"] {
+    [data-allowance-type="self-plus-dependents"] {
       display: none;
     }
   }
 
-  &[data\-dependency\-status="true"] {
-    [data\-allowance\-type="self"] {
+  &[data-dependency-status="true"] {
+    [data-allowance-type="self"] {
       display: none;
     }
   }
 
-  &[data\-move\-type="conus"] {
+  &[data-move-type="conus"] {
     .oconus-details,
     .conus-details h5 {
       display: none;
     }
   }
 
-  &[data\-move\-type="oconus"] {
+  &[data-move-type="oconus"] {
     .conus-details,
     .oconus-details h5 {
       display: none;

--- a/src/_data/moving_allowance_categories.yml
+++ b/src/_data/moving_allowance_categories.yml
@@ -3,7 +3,9 @@
   categories:
     - title: Total Weight of Household Goods
       id: total-weight-of-household-goods
-      allowance_key: total_weight
+      allowance_keys:
+        - total_weight_self
+        - total_weight_self_plus_dependents
       details:
         <ul>
           <li>Excludes Pro-Gear (items used professionally for work).</li>
@@ -114,7 +116,8 @@
   categories:
     - title: Service Member Pro-Gear
       id: service-member-pro-gear
-      allowance_key: pro_gear
+      allowance_keys:
+        - pro_gear
       details: >
         <ul>
           <li>Professional equipment must be completely separated from the rest of your items so that they can be packed, marked, and weighed separately.</li>
@@ -136,7 +139,8 @@
 
     - title: Spouse Pro-Gear
       id: spouse-pro-gear
-      allowance_key: spouse_pro_gear
+      allowance_keys:
+        - pro_gear_spouse
       details: >
         <ul>
           <li>Professional equipment must be completely separated from your spouse’s pro-gear and from rest of your family’s items. All of your pro-gear will be packed, marked, and weighed separately.</li>

--- a/src/_data/pay_grades.yml
+++ b/src/_data/pay_grades.yml
@@ -1,204 +1,143 @@
 - rank: Service Academy Cadets/Midshipmen
   allowances:
-    total_weight:
-      self: 350 lbs.
+    total_weight_self: 350 lbs.
 
 - rank: Aviation Cadets
   allowances:
-    total_weight:
-      self: 7,000 lbs.
-      self_plus_dependents: 8,000 lbs.
-    pro_gear:
-      self: 2,000 lbs.
-    spouse_pro_gear:
-      self: 500 lbs.
+    total_weight_self: 7,000 lbs.
+    total_weight_self_plus_dependents: 8,000 lbs.
+    pro_gear: 2,000 lbs.
+    pro_gear_spouse: 500 lbs.
 
 - rank: E-1
   allowances:
-    total_weight:
-      self: 5,000 lbs.
-      self_plus_dependents: 8,000 lbs.
-    pro_gear:
-      self: 2,000 lbs.
-    spouse_pro_gear:
-      self: 500 lbs.
+    total_weight_self: 5,000 lbs.
+    total_weight_self_plus_dependents: 8,000 lbs.
+    pro_gear: 2,000 lbs.
+    pro_gear_spouse: 500 lbs.
 
 - rank: E-2
   allowances:
-    total_weight:
-      self: 5,000 lbs.
-      self_plus_dependents: 8,000 lbs.
-    pro_gear:
-      self: 2,000 lbs.
-    spouse_pro_gear:
-      self: 500 lbs.
+    total_weight_self: 5,000 lbs.
+    total_weight_self_plus_dependents: 8,000 lbs.
+    pro_gear: 2,000 lbs.
+    pro_gear_spouse: 500 lbs.
 
 - rank: E-3
   allowances:
-    total_weight:
-      self: 5,000 lbs.
-      self_plus_dependents: 8,000 lbs.
-    pro_gear:
-      self: 2,000 lbs.
-    spouse_pro_gear:
-      self: 500 lbs.
+    total_weight_self: 5,000 lbs.
+    total_weight_self_plus_dependents: 8,000 lbs.
+    pro_gear: 2,000 lbs.
+    pro_gear_spouse: 500 lbs.
 
 - rank: E-4
   allowances:
-    total_weight:
-      self: 7,000 lbs.
-      self_plus_dependents: 8,000 lbs.
-    pro_gear:
-      self: 2,000 lbs.
-    spouse_pro_gear:
-      self: 500 lbs.
+    total_weight_self: 7,000 lbs.
+    total_weight_self_plus_dependents: 8,000 lbs.
+    pro_gear: 2,000 lbs.
+    pro_gear_spouse: 500 lbs.
 
 - rank: E-5
   allowances:
-    total_weight:
-      self: 7,000 lbs.
-      self_plus_dependents: 9,000 lbs.
-    pro_gear:
-      self: 2,000 lbs.
-    spouse_pro_gear:
-      self: 500 lbs.
+    total_weight_self: 7,000 lbs.
+    total_weight_self_plus_dependents: 9,000 lbs.
+    pro_gear: 2,000 lbs.
+    pro_gear_spouse: 500 lbs.
 
 - rank: E-6
   allowances:
-    total_weight:
-      self: 8,000 lbs.
-      self_plus_dependents: 11,000 lbs.
-    pro_gear:
-      self: 2,000 lbs.
-    spouse_pro_gear:
-      self: 500 lbs.
+    total_weight_self: 8,000 lbs.
+    total_weight_self_plus_dependents: 11,000 lbs.
+    pro_gear: 2,000 lbs.
+    pro_gear_spouse: 500 lbs.
 
 - rank: E-7
   allowances:
-    total_weight:
-      self: 11,000 lbs.
-      self_plus_dependents: 13,000 lbs.
-    pro_gear:
-      self: 2,000 lbs.
-    spouse_pro_gear:
-      self: 500 lbs.
+    total_weight_self: 11,000 lbs.
+    total_weight_self_plus_dependents: 13,000 lbs.
+    pro_gear: 2,000 lbs.
+    pro_gear_spouse: 500 lbs.
 
 - rank: E-8
   allowances:
-    total_weight:
-      self: 12,000 lbs.
-      self_plus_dependents: 14,000 lbs.
-    pro_gear:
-      self: 2,000 lbs.
-    spouse_pro_gear:
-      self: 500 lbs.
+    total_weight_self: 12,000 lbs.
+    total_weight_self_plus_dependents: 14,000 lbs.
+    pro_gear: 2,000 lbs.
+    pro_gear_spouse: 500 lbs.
 
 - rank: E-9
   allowances:
-    total_weight:
-      self: 13,000 lbs.
-      self_plus_dependents: 15,000 lbs.
-    pro_gear:
-      self: 2,000 lbs.
-    spouse_pro_gear:
-      self: 500 lbs.
+    total_weight_self: 13,000 lbs.
+    total_weight_self_plus_dependents: 15,000 lbs.
+    pro_gear: 2,000 lbs.
+    pro_gear_spouse: 500 lbs.
 
 - rank: O-1/W-1/Service Academy Graduates
   allowances:
-    total_weight:
-      self: 10,000 lbs.
-      self_plus_dependents: 12,000 lbs.
-    pro_gear:
-      self: 2,000 lbs.
-    spouse_pro_gear:
-      self: 500 lbs.
+    total_weight_self: 10,000 lbs.
+    total_weight_self_plus_dependents: 12,000 lbs.
+    pro_gear: 2,000 lbs.
+    pro_gear_spouse: 500 lbs.
 
 - rank: O-2/W-2
   allowances:
-    total_weight:
-      self: 12,500 lbs.
-      self_plus_dependents: 13,500 lbs.
-    pro_gear:
-      self: 2,000 lbs.
-    spouse_pro_gear:
-      self: 500 lbs.
+    total_weight_self: 12,500 lbs.
+    total_weight_self_plus_dependents: 13,500 lbs.
+    pro_gear: 2,000 lbs.
+    pro_gear_spouse: 500 lbs.
 
 - rank: O-3/W-3
   allowances:
-    total_weight:
-      self: 13,000 lbs.
-      self_plus_dependents: 14,500 lbs.
-    pro_gear:
-      self: 2,000 lbs.
-    spouse_pro_gear:
-      self: 500 lbs.
+    total_weight_self: 13,000 lbs.
+    total_weight_self_plus_dependents: 14,500 lbs.
+    pro_gear: 2,000 lbs.
+    pro_gear_spouse: 500 lbs.
 
 - rank: O-4/W-4
   allowances:
-    total_weight:
-      self: 14,000 lbs.
-      self_plus_dependents: 17,500 lbs.
-    pro_gear:
-      self: 2,000 lbs.
-    spouse_pro_gear:
-      self: 500 lbs.
+    total_weight_self: 14,000 lbs.
+    total_weight_self_plus_dependents: 17,500 lbs.
+    pro_gear: 2,000 lbs.
+    pro_gear_spouse: 500 lbs.
 
 - rank: O-5/W-5
   allowances:
-    total_weight:
-      self: 16,000 lbs.
-      self_plus_dependents: 17,500 lbs.
-    pro_gear:
-      self: 2,000 lbs.
-    spouse_pro_gear:
-      self: 500 lbs.
+    total_weight_self: 16,000 lbs.
+    total_weight_self_plus_dependents: 17,500 lbs.
+    pro_gear: 2,000 lbs.
+    pro_gear_spouse: 500 lbs.
 
 - rank: O-6
   allowances:
-    total_weight:
-      self: 18,000 lbs.
-      self_plus_dependents: 18,000 lbs.
-    pro_gear:
-      self: 2,000 lbs.
-    spouse_pro_gear:
-      self: 500 lbs.
+    total_weight_self: 18,000 lbs.
+    total_weight_self_plus_dependents: 18,000 lbs.
+    pro_gear: 2,000 lbs.
+    pro_gear_spouse: 500 lbs.
 
 - rank: O-7
   allowances:
-    total_weight:
-      self: 18,000 lbs.
-      self_plus_dependents: 18,000 lbs.
-    pro_gear:
-      self: 2,000 lbs.
-    spouse_pro_gear:
-      self: 500 lbs.
+    total_weight_self: 18,000 lbs.
+    total_weight_self_plus_dependents: 18,000 lbs.
+    pro_gear: 2,000 lbs.
+    pro_gear_spouse: 500 lbs.
 
 - rank: O-8
   allowances:
-    total_weight:
-      self: 18,000 lbs.
-      self_plus_dependents: 18,000 lbs.
-    pro_gear:
-      self: 2,000 lbs.
-    spouse_pro_gear:
-      self: 500 lbs.
+    total_weight_self: 18,000 lbs.
+    total_weight_self_plus_dependents: 18,000 lbs.
+    pro_gear: 2,000 lbs.
+    pro_gear_spouse: 500 lbs.
 
 - rank: O-9
   allowances:
-    total_weight:
-      self: 18,000 lbs.
-      self_plus_dependents: 18,000 lbs.
-    pro_gear:
-      self: 2,000 lbs.
-    spouse_pro_gear:
-      self: 500 lbs.
+    total_weight_self: 18,000 lbs.
+    total_weight_self_plus_dependents: 18,000 lbs.
+    pro_gear: 2,000 lbs.
+    pro_gear_spouse: 500 lbs.
 
 - rank: O-10
   allowances:
-    total_weight:
-      self: 18,000 lbs.
-      self_plus_dependents: 18,000 lbs.
-    pro_gear:
-      self: 2,000 lbs.
-    spouse_pro_gear:
-      self: 500 lbs.
+    total_weight_self: 18,000 lbs.
+    total_weight_self_plus_dependents: 18,000 lbs.
+    pro_gear: 2,000 lbs.
+    pro_gear_spouse: 500 lbs.

--- a/src/moving-allowances/determine-your-allowance/index.html
+++ b/src/moving-allowances/determine-your-allowance/index.html
@@ -66,25 +66,18 @@ title: Determine Your Moving Allowance
                 <td><b>{{ subcategory.allowance }}</b></td>
                 <td><a href="#{{ subcategory.id }}" class="view-details">View details</a></td>
               </tr>
-            {% elsif subcategory.allowance_key %}
-              {% assign allowances_self = pay_grade.allowances[subcategory.allowance_key].self %}
-              {% assign allowances_self_plus_depedendents = pay_grade.allowances[subcategory.allowance_key].self_plus_dependents %}
+            {% elsif subcategory.allowance_keys %}
+              {% for allowance_key in subcategory.allowance_keys %}
+                {% assign allowance_value = pay_grade.allowances[allowance_key] %}
 
-              {% if allowances_self %}
-                <tr data-allowance-type="self">
-                  <th scope="row">{{ subcategory.title }}</th>
-                  <td><b>{{ allowances_self }}</b></td>
-                  <td><a href="#{{ subcategory.id }}" class="view-details">View details</a></td>
-                </tr>
-              {% endif %}
-
-              {% if allowances_self_plus_depedendents %}
-                <tr data-allowance-type="self-plus-dependents">
-                  <th scope="row">{{ subcategory.title }} <i>(with dependents)</i></th>
-                  <td><b>{{ allowances_self_plus_depedendents }}</b></td>
-                  <td><a href="#{{ subcategory.id }}" class="view-details">View details</a></td>
-                </tr>
-              {% endif %}
+                {% if allowance_value %}
+                  <tr data-allowance-key="{{ allowance_key }}">
+                    <th scope="row">{{ subcategory.title }}{% if allowance_key == 'total_weight_self_plus_dependents' %} <i>(with dependents)</i>{% endif %}</th>
+                    <td><b>{{ allowance_value }}</b></td>
+                    <td><a href="#{{ subcategory.id }}" class="view-details">View details</a></td>
+                  </tr>
+                {% endif %}
+              {% endfor %}
             {% endif %}
           {% endfor %}
         </tbody>

--- a/src/moving-allowances/determine-your-allowance/index.html
+++ b/src/moving-allowances/determine-your-allowance/index.html
@@ -25,8 +25,8 @@ title: Determine Your Moving Allowance
   <label for="move-type">3. Specify your <b>move type</b>.</label>
   <select id="move-type">
     <option value=""></option>
-    <option value="CONUS">Within the Continental United States (CONUS)</option>
-    <option value="OCONUS">Outside of the Continental United States (OCONUS)</option>
+    <option value="conus">Within the Continental United States (CONUS)</option>
+    <option value="oconus">Outside of the Continental United States (OCONUS)</option>
   </select>
 
   <button>View Results</button>
@@ -64,7 +64,7 @@ title: Determine Your Moving Allowance
               <tr>
                 <th scope="row">{{ subcategory.title }}</th>
                 <td><b>{{ subcategory.allowance }}</b></td>
-                <td><a href="#{{ subcategory.id }}">View details</a></td>
+                <td><a href="#{{ subcategory.id }}" class="view-details">View details</a></td>
               </tr>
             {% elsif subcategory.allowance_key %}
               {% assign allowances_self = pay_grade.allowances[subcategory.allowance_key].self %}
@@ -74,7 +74,7 @@ title: Determine Your Moving Allowance
                 <tr data-allowance-type="self">
                   <th scope="row">{{ subcategory.title }}</th>
                   <td><b>{{ allowances_self }}</b></td>
-                  <td><a href="#{{ subcategory.id }}">View details</a></td>
+                  <td><a href="#{{ subcategory.id }}" class="view-details">View details</a></td>
                 </tr>
               {% endif %}
 
@@ -82,7 +82,7 @@ title: Determine Your Moving Allowance
                 <tr data-allowance-type="self-plus-dependents">
                   <th scope="row">{{ subcategory.title }} <i>(with dependents)</i></th>
                   <td><b>{{ allowances_self_plus_depedendents }}</b></td>
-                  <td><a href="#{{ subcategory.id }}">View details</a></td>
+                  <td><a href="#{{ subcategory.id }}" class="view-details">View details</a></td>
                 </tr>
               {% endif %}
             {% endif %}
@@ -100,7 +100,7 @@ title: Determine Your Moving Allowance
     <h3>{{ category.title }}</h3>
 
     {% for subcategory in category.categories %}
-      <div id="{{ subcategory.id }}">
+      <div class="moving-allowances-tips" id="{{ subcategory.id }}">
         <h4>{{ subcategory.title }}</h4>
 
         {% if subcategory.details.conus or subcategory.details.oconus %}
@@ -123,7 +123,7 @@ title: Determine Your Moving Allowance
           {{ subcategory.details }}
         {% endif %}
 
-        <a href="#moving-allowances">Return to Moving Allowances</a>
+        <a href="#moving-allowances" class="return-to-moving-allowances">Return to Moving Allowances</a>
       </div>
     {% endfor %}
   {% endfor %}

--- a/src/moving-allowances/index.html
+++ b/src/moving-allowances/index.html
@@ -7,7 +7,7 @@ title: Moving Allowances (Entitlements) Overview
 
 <p>As questions arise, your <a href="#TODO">Transportation Office (TO)</a> can provide further information and generally is the best place to get help related to your move.</p>
 
-<h2><abbr title="Continental United States">CONUS</abbr> vs. <abbr title="Outside Continental United States">OCONUS</abbr> Moves</h2>
+<h2 class="divider-heading"><span>Military Terms Explained</span></h2>
 
 <div class="usa-grid conus-vs-oconus-moves">
   <div class="usa-width-one-half">


### PR DESCRIPTION
## Checklist

I have…

- [x] built and served the site locally (`bundle exec rake jekyll:serve`) and verified that my changes behave as expected.
- [ ] run the test suite (`bundle exec rake`) and verified that all tests pass.
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.

**Note:** The test suite does not pass owing to some `<a href="#TODO">` anchors that will be updated later.

## Summary of Changes

This pull request refines the JavaScript-powered enhancements to the "Determine Your Moving Allowance" page. User input from all three `<select>`s are used to determine which allowance table is shown and, within that allowance table, which rows and content are conditionally shown.

The JavaScript takes the "View details" anchor links that are in the `<table>`s' markup, grabs a reference to the linked node (based on the anchor's `href` / hash), clones that markup, and inserts it into the `<table>` _after_ the "View details" anchor. The tips content and the "View details" anchors are shown or hidden depending on the width of the viewport.

## Testing

To verify the changes proposed in this pull request…

1. clone this repo and set up development dependencies,
1. `git checkout enhance-moving-allowances-page`,
1. `bundle exec rake jekyll:serve`,
1. point your Web browser of choice at http://localhost:4000/moving-allowances/determine-your-allowance/,
1. choose different combinations of replies to the three `<select>`s, and
1. observe the resulting allowance tables display content matched to the supplied `<select>` values.
