### PR TITLE
Add Damage Claims Overview content

### DIFF
--- a/src/_assets/stylesheets/application.scss
+++ b/src/_assets/stylesheets/application.scss
@@ -55,6 +55,7 @@ $moving-allowances-wide: 950px;
 
 // Site -------------- //
 @import "elements/inputs";
+@import "elements/list";
 @import "elements/table";
 @import "elements/typography";
 @import "components/footer";

--- a/src/_assets/stylesheets/elements/_list.scss
+++ b/src/_assets/stylesheets/elements/_list.scss
@@ -1,0 +1,36 @@
+.claims-process-list {
+  @supports(counter-increment: item) {
+    > li {
+      counter-increment: item;
+      padding-left: 5.4rem;
+      position: relative;
+
+      &:before {
+        background-color: $color-primary;
+        border-radius: 50%;
+        color: $color-white;
+        content: counter(item);
+        display: inline-block;
+        font-size: 2.4rem;
+        font-weight: $font-bold;
+        height: 3.6rem;
+        left: 0;
+        position: absolute;
+        text-align: center;
+        top: 0;
+        width: 3.6rem;
+      }
+    }
+
+    h3 {
+      padding-top: 0.5rem;
+    }
+  }
+
+  h3 span {
+    display: block;
+    font-family: $font-sans;
+    font-size: $h5-font-size;
+    font-weight: $font-normal;
+  }
+}

--- a/src/_data/navigation.yml
+++ b/src/_data/navigation.yml
@@ -21,8 +21,12 @@
     - title: Estimate Weight Allowance
       url: /estimate-weight-allowance
 
-- title: File and Manage Claims
+- title: Damage Claims
   url: /claims
+
+  subnav:
+    - title: Frequently Asked Questions
+      url: /faqs
 
 - title: Service-Specific Information
   url: /service-specific-information

--- a/src/claims/faqs/index.html
+++ b/src/claims/faqs/index.html
@@ -1,0 +1,4 @@
+---
+layout: page
+title: Frequently Asked Questions
+---

--- a/src/claims/index.html
+++ b/src/claims/index.html
@@ -1,4 +1,76 @@
 ---
 layout: page
-title: File and Manage Claims
+title: Damage Claims Overview
 ---
+
+<p>After your move is completed, you should file a claim for anything that has been broken, damaged, or lost by your Transportation Service Provider (TSP). <b>Be sure to follow the specific deadlines to submit a claim which starts from the delivery date of your goods.</b></p>
+<p>As questions arise, your <a href="#TODO">Transportation Office (TO)</a> or your <a href="#TODO">Military Claims Office (MCO)</a> can provide further information and generally is the best place to get help related to your move.</p>
+
+<h2 class="divider-heading"><span>Learn the Process</span></h2>
+
+<ol class="claims-process-list usa-unstyled-list">
+  <li>
+    <h3>
+      Initial inspection of items during delivery
+      <span>(Delivery Day)</span>
+    </h3>
+
+    <p>While your household goods are being delivered, do your best to note items that were lost or damaged by your Transportation Service Provider (TSP).</p>
+    <p><b>If anything obviously appears missing or damaged, make sure you and the <abbr title="Transportation Service Provider">TSP</abbr> both sign the <a href="#TODO">DD-1840: Notification of Loss/Damage at Delivery Form</a> before the carrier leaves.</b> The purpose of DD-1840 is to inform the Transportation Service Provider of your intention to file specific item claims at a later date. Save your copy in a safe place.</p>
+    <p><b>IMPORTANT:</b> If you scheduled your move through DPS, you will also need to file the DD-1840 electronically within 30 days of your shipment delivery date along with a detailed claim for each lost or damaged item.</p>
+  </li>
+  <li>
+    <h3>
+      Electronically file your DD-1840
+      <span>(Up to 30 days after shipment delivery)</span>
+    </h3>
+
+    <p>If you scheduled your move through DPS, you will also need to file the <a href="#TODO">DD-1840: Notification of Loss/Damage at Delivery Form</a> electronically within 30 days of your shipment delivery date.</p>
+  </li>
+  <li>
+    <h3>
+      Inform your <abbr title="Transportation Service Provider">TSP</abbr> of any additional lost or damaged items
+      <span>(Up to 75 days after shipment delivery)</span>
+    </h3>
+
+    <p>As you unpack and get settled into your new housing, you may notice that additional items have been lost, damaged or broken. In this case, any additional damages can be reported to the transporter with the DD-1840R: Notification of Loss/Damage after Delivery Form up to 75 calendar days from your shipment delivery. If you scheduled your move through DPS, the DD 1840R needs to be filed electronically within DPS. After 75 days after your shipment delivery, the transporter is not responsible for any damages caused by your move.</p>
+    <p><b>NOTE:</b> The <abbr title="Transportation Service Provider">TSP</abbr> has the right to return and inspect any damaged items so do not dispose of them until 1) you have accepted financial compensation for the item, or 2) the Military Claims Office (MCO) informs you that you no longer need to save the item.</p>
+  </li>
+  <li>
+    <h3>
+      File your claims
+      <span>(Up to 9 months after shipment delivery )</span>
+    </h3>
+
+    <p>To recieve compensation for any lost or damaged item, each item must have a claim filed within DPS within 9 months after your shipment delivery. The electronic filing of the DD-1840 and the DD-1840R is not sufficient to recieve reimbursement. For each item, you will need to collect and enter the following information:</p>
+    <ul>
+      <li><b>Item Description</b></li>
+      <li><b>Purchase Price</b></li>
+      <li><b>Purchase Year</b></li>
+      <li><b>Inventory Number</b></li>
+      <li><b>Claim Amount Requested</b> (service members are entitled to the full replacement value for claims filed within 9 months after delivery)</li>
+      <li><b>Evidence*</b></li>
+    </ul>
+    <p>* Providing evidence of the damage is optional, however can greatly increase the financial compensation the <abbr title="Transportation Service Provider">TSP</abbr> offers to you. Ideal evidence would be a photo of the object taken during your pre-move inspection paired with a photo of the damaged item post move.</p>
+    <p><a href="#TODO">Learn how to file a claim in DPS</a></p>
+  </li>
+  <li>
+    <h3>Negotiate your settlement with your <abbr title="Transportation Service Provider">TSP</abbr></h3>
+
+    <p>Once you file a claim on DPS, your transportation service provider will respond potentially offering financial compensation for your item. Your options are to accept the amount or reject and renegotiate the amount.</p>
+    <p>NOTE: Once you accept financial compensation for an item, you cannot recieve additional compensation from any other claims process.</p>
+    <p><a href="#TODO">What financial compensation is my <abbr title="Transportation Service Provider">TSP</abbr> required to provide for my lost or damaged items?</a></p>
+  </li>
+  <li>
+    <h3>Ask your Military Claims Office (MCO) for assistance</h3>
+
+    <p>If you are unable to negotiate a settlement with your Transportation Service Provider (TSP) through DPS, or if you have any questions regarding claims benefits or deadlines, you should contact your <a href="#TODO">Military Claims Office (MCO)</a> or service-specfic claims group for additional assistance. In some cases, the Military Claims Office can help you secure partial replacement items for up to two years after your move.</p>
+    <ul>
+      <li><a href="https://www.jagcnet5.army.mil/pclaims" class="usa-external_link">Army Claims</a></li>
+      <li><a href="https://www.manpower.usmc.mil/webcenter/portal/MF_MPS/PersonalPropertyClaims?_adf.ctrl-state=folp34ytc_38&_afrLoop=297348451550785#!" class="usa-external_link">Marines Claims</a></li>
+      <li><a href="http://www.jag.navy.mil/organization/code_15_packets_forms.htm" class="usa-external_link">Navy Claims</a></li>
+      <li><a href="https://claims.jag.af.mil/" class="usa-external_link">Air Force Claims</a></li>
+      <li><a href="http://www.fincen.uscg.mil/hhg.htm" class="usa-external_link">Coast Guard Claims</a></li>
+    </ul>
+  </li>
+</ol>


### PR DESCRIPTION
## Checklist

I have…

- [x] built and served the site locally (`bundle exec rake jekyll:serve`) and verified that my changes behave as expected.
- [ ] run the test suite (`bundle exec rake`) and verified that all tests pass.
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.

**Note:** The test suite currently fails owing to some `<a href="#TODO">` anchors in page content.

## Summary of Changes

This pull request adds content to the "Damage Claims Overview" page. It also adds a (for now) blank "Frequently Asked Questions" page organized under the Claims section.

## Testing

To verify the changes proposed in this pull request…

1. clone this repo and set up development dependencies,
1. `git checkout add-damage-claims-content`,
1. `bundle exec rake jekyll:serve`,
1. point your Web browser of choice at http://localhost:4000/claims/,
1. observe that the site renders and behaves as shown in the (partial) screenshots below.

## Screenshots

### Narrow viewport

![narrow](https://cloud.githubusercontent.com/assets/27780860/26589667/8d0036c4-4526-11e7-8650-e397c254f48d.png)

### Wide viewport

![wide](https://cloud.githubusercontent.com/assets/27780860/26589656/882e0bc6-4526-11e7-9b08-f28130e39d7b.png)