### PR TITLE
Add DPS login below sidebar navigation

### DIFF
--- a/src/_assets/stylesheets/components/_section.scss
+++ b/src/_assets/stylesheets/components/_section.scss
@@ -1,6 +1,22 @@
 .dps-login-section {
   @include padding($site-margins-mobile);
   background-color: $color-gray-lightest;
+
+  .usa-layout-docs-sidenav & {
+    @include margin($site-margins null);
+    @include padding($site-margins 0);
+    background-color: transparent;
+    border-top: 0.25rem solid $color-primary-darkest;
+  }
+
+  p:first-child {
+    margin-top: 0;
+  }
+
+  .usa-button {
+    display: block;
+    margin: 0;
+  }
 }
 
 .homepage-section {

--- a/src/_layouts/page.html
+++ b/src/_layouts/page.html
@@ -21,6 +21,11 @@ layout: application
         </li>
       {% endfor %}
     </ul>
+
+    <div class="dps-login-section">
+      <p><a href="https://eta.sddc.army.mil/ETASSOPortal/SSO/AppLogin.aspx?LoginType=portal&SSOAppID=DPS" class="usa-button">Log In to DPS</a></p>
+      <p class="usa-text-small">New to <abbr title="Defense Personal Property System">DPS</abbr>? <a href="https://www.move.mil/dod/first_time_users/browser_compatibility.cfm">Create your account</a></p>
+    </div>
   </aside>
 
   <div class="usa-width-three-fourths usa-layout-docs-main_content">

--- a/src/_layouts/page.html
+++ b/src/_layouts/page.html
@@ -23,7 +23,7 @@ layout: application
     </ul>
 
     <div class="dps-login-section">
-      <p><a href="https://eta.sddc.army.mil/ETASSOPortal/SSO/AppLogin.aspx?LoginType=portal&SSOAppID=DPS" class="usa-button">Log In to DPS</a></p>
+      <p><a href="https://eta.sddc.army.mil/ETASSOPortal/SSO/AppLogin.aspx?LoginType=portal&amp;SSOAppID=DPS" class="usa-button">Log In to DPS</a></p>
       <p class="usa-text-small">New to <abbr title="Defense Personal Property System">DPS</abbr>? <a href="https://www.move.mil/dod/first_time_users/browser_compatibility.cfm">Create your account</a></p>
     </div>
   </aside>

--- a/src/index.html
+++ b/src/index.html
@@ -10,7 +10,7 @@ layout: application
   <aside class="usa-width-one-third">
     <div class="dps-login-section">
       <p><b>Defense Personal Property System (DPS)</b> is your portal to move scheduling and the claims process.</p>
-      <p><a href="https://eta.sddc.army.mil/ETASSOPortal/SSO/AppLogin.aspx?LoginType=portal&SSOAppID=DPS" class="usa-button">Log In to DPS</a></p>
+      <p><a href="https://eta.sddc.army.mil/ETASSOPortal/SSO/AppLogin.aspx?LoginType=portal&amp;SSOAppID=DPS" class="usa-button">Log In to DPS</a></p>
       <p class="usa-text-small">New to <abbr title="Defense Personal Property System">DPS</abbr>? <a href="https://www.move.mil/dod/first_time_users/browser_compatibility.cfm">Create your account</a></p>
     </div>
   </aside>

--- a/src/index.html
+++ b/src/index.html
@@ -7,10 +7,12 @@ layout: application
 </div>
 
 <div class="usa-grid">
-  <aside class="usa-width-one-third dps-login-section">
-    <p><b>Defense Personal Property System (DPS)</b> is your portal to move scheduling and the claims process.</p>
-    <p><a href="https://eta.sddc.army.mil/ETASSOPortal/SSO/AppLogin.aspx?LoginType=portal&SSOAppID=DPS" class="usa-button">Log In to DPS</a></p>
-    <p class="usa-text-small">New to <abbr title="Defense Personal Property System">DPS</abbr>? <a href="https://www.move.mil/dod/first_time_users/browser_compatibility.cfm">Create your account</a></p>
+  <aside class="usa-width-one-third">
+    <div class="dps-login-section">
+      <p><b>Defense Personal Property System (DPS)</b> is your portal to move scheduling and the claims process.</p>
+      <p><a href="https://eta.sddc.army.mil/ETASSOPortal/SSO/AppLogin.aspx?LoginType=portal&SSOAppID=DPS" class="usa-button">Log In to DPS</a></p>
+      <p class="usa-text-small">New to <abbr title="Defense Personal Property System">DPS</abbr>? <a href="https://www.move.mil/dod/first_time_users/browser_compatibility.cfm">Create your account</a></p>
+    </div>
   </aside>
 
   <div class="usa-width-two-thirds">


### PR DESCRIPTION
## Checklist

I have…

- [x] built and served the site locally (`bundle exec rake jekyll:serve`) and verified that my changes behave as expected.
- [x] run the test suite (`bundle exec rake`) and verified that all tests pass.
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.

**Note:** The test suite currently fails owing to some `<a href="#TODO">` anchors in page content.

## Summary of Changes

This pull request adds a version of the DPS login box from the homepage to interior pages beneath the sidebar navigation.

## Testing

To verify the changes proposed in this pull request…

1. clone this repo and set up development dependencies,
1. `git checkout add-dps-login-to-sidebar`,
1. `bundle exec rake jekyll:serve`,
1. point your Web browser of choice at http://localhost:4000/claims/,
1. observe that the site renders and behaves as shown in the (partial) screenshots below.

## Screenshots

### Narrow Viewport

<img width="447" alt="screen shot 2017-06-19 at 10 01 02 am" src="https://user-images.githubusercontent.com/27780860/27288964-592bd898-54d6-11e7-9cbc-7795afee9a4e.png">

### Wide Viewport

<img width="1365" alt="screen shot 2017-06-19 at 10 00 41 am" src="https://user-images.githubusercontent.com/27780860/27288970-60f5dd08-54d6-11e7-9f0b-efdc25c8e2f4.png">