### PR TITLE
Use manifest.js to configure assets for precompilation

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,3 +1,5 @@
 //= link_tree ../images
 //= link_directory ../javascripts .js
 //= link_directory ../stylesheets .css
+
+//= link html5shiv.js

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -6,9 +6,9 @@ Rails.application.config.assets.version = '1.0'
 # Add additional assets to the asset load path.
 # Rails.application.config.assets.paths << Emoji.images_path
 # Add Yarn node_modules folder to the asset load path.
-Rails.application.config.assets.paths << Rails.root.join('node_modules')
+# Rails.application.config.assets.paths << Rails.root.join('node_modules')
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets
 # folder are already added.
-Rails.application.config.assets.precompile += %w[html5shiv.js]
+Rails.application.config.assets.precompile += %w[manifest.js]

--- a/package.json
+++ b/package.json
@@ -1,5 +1,0 @@
-{
-  "name": "move_mil",
-  "private": true,
-  "dependencies": {}
-}


### PR DESCRIPTION
## Checklist

I have…

- [x] run the application locally (`bin/rails server`) and verified that my changes behave as expected.
- [x] run static code analysis (`bin/rubocop`) and vulnerability scan (`bin/brakeman`) against my changes.
- [x] run the test suite (`bin/rake spec`) and verified that all tests pass.
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.

## Summary of Changes

This pull request switches asset precompilation configuration from `config/initializers/assets.rb` to `app/assets/config/manifest.js` which is a new(ish?) [Sprockets](https://github.com/rails/sprockets) thing. It's a little bit cleaner defining assets that require linking here than in `assets.rb`.

Practically speaking, assets that aren't automatically linked (by virtue of being `//= require`d or `@import`ed in `application.js` or `application.scss`) should be defined in `manifest.js`. I poked at the manifest's different directives (e.g. `link`, `link_tree`, etc.) and couldn't find a way to link _all_ assets of a given type provided by a gem. That means that for a third-party library like Leaflet (when included as a rails-assets.org gem), we'll need to declare each asset individually with a `//= link` directive.

This PR also disables appending of `node_modules` to `config.assets.paths` and removes `package.json`. I don't anticipate we'll be using [Yarn](https://yarnpkg.com) for dependencies. If we do, we can always add it back.

## Testing

To verify the changes proposed in this pull request…

1. clone this repo,
1. `git checkout refactor-asset-config`,
1. set up development dependencies according to `CONTRIBUTING.md`,
1. `bin/rails server`, and
1. load up http://localhost:3000 in your Web browser of choice.