### PR TITLE
Refactor navigation to use active_link_to gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ end
 source 'https://rubygems.org'
 source 'https://rails-assets.org'
 
+gem 'active_link_to', '~> 1.0'
 gem 'friendly_id', '~> 5.2', '>= 5.2.1'
 gem 'high_voltage', '~> 3.0'
 gem 'pg', '~> 0.21.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,6 +25,9 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    active_link_to (1.0.4)
+      actionpack
+      addressable
     activejob (5.1.3)
       activesupport (= 5.1.3)
       globalid (>= 0.3.6)
@@ -39,6 +42,8 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.5.1)
+      public_suffix (~> 2.0, >= 2.0.2)
     ansi (1.5.0)
     arel (8.0.0)
     ast (2.3.0)
@@ -93,6 +98,7 @@ GEM
       ast (~> 2.2)
     pg (0.21.0)
     powerpack (0.1.1)
+    public_suffix (2.0.5)
     puma (3.9.1)
     rack (2.0.3)
     rack-test (0.6.3)
@@ -212,6 +218,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_link_to (~> 1.0)
   brakeman (~> 3.7)
   byebug (~> 9.0, >= 9.0.6)
   dotenv-rails (~> 2.2, >= 2.2.1)

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -4,6 +4,7 @@ This project uses a number of open source components whose licenses are noted be
 
 | Project | Copyright | License |
 |---------|-----------|---------|
+| [active_link_to](https://github.com/comfy/active_link_to) | © 2009–2017 [Oleg Khabarov](https://github.com/GBH) | [MIT License](https://github.com/comfy/active_link_to/blob/master/LICENSE) |
 | [Brakeman](https://github.com/presidentbeef/brakeman) | © 2012 Twitter, Inc. | [MIT License](https://github.com/presidentbeef/brakeman/blob/master/MIT-LICENSE) |
 | [Byebug](https://github.com/deivid-rodriguez/byebug) | © [David Rodríguez](https://github.com/deivid-rodriguez) | [BSD 2-Clause License](https://github.com/deivid-rodriguez/byebug/blob/master/LICENSE) |
 | [factory_girl_rails](https://github.com/thoughtbot/factory_girl_rails) | © 2008–2013 [Joe Ferris](https://github.com/jferris) and [thoughtbot, inc.](https://thoughtbot.com) | [MIT License](https://github.com/thoughtbot/factory_girl_rails/blob/master/LICENSE) |

--- a/app/views/shared/_sidenav.html.erb
+++ b/app/views/shared/_sidenav.html.erb
@@ -1,51 +1,23 @@
 <aside class="usa-width-one-fourth usa-layout-docs-sidenav">
   <ul class="usa-sidenav-list">
     <li>
-      <%= link_to 'Moving with the Military', page_path('moving-guide'), class: params[:id].try(:include?, 'moving-guide') ? 'usa-current' : nil %>
+      <%= active_link_to 'Moving with the Military', page_path('moving-guide'), class_active: 'usa-current' %>
 
-      <%- if params[:id].try(:include?, 'moving-guide') -%>
+      <%- if is_active_link?(page_path('moving-guide')) -%>
         <ul class="usa-sidenav-sub_list">
-          <li>
-            <%= link_to page_path('moving-guide/conus'), class: current_page?(id: 'moving-guide/conus') ? 'usa-current' : nil do %>
-              <i>What to expect…</i> <%= abbr_tag('conus') %> <%= abbr_tag('pcs') %>
-            <% end %>
-          </li>
-          <li>
-            <%= link_to page_path('moving-guide/oconus'), class: current_page?(id: 'moving-guide/oconus') ? 'usa-current' : nil do %>
-              <i>What to expect…</i> <%= abbr_tag('oconus') %> <%= abbr_tag('pcs') %>
-            <% end %>
-          </li>
-          <li>
-            <%= link_to page_path('moving-guide/tdy'), class: current_page?(id: 'moving-guide/tdy') ? 'usa-current' : nil do %>
-              <i>What to expect…</i> <%= abbr_tag('tdy') %>
-            <% end %>
-          </li>
-          <li>
-            <%= link_to page_path('moving-guide/retirees-separatees'), class: current_page?(id: 'moving-guide/retirees-separatees') ? 'usa-current' : nil do %>
-              <i>What to expect…</i> Retirees/Separatees
-            <% end %>
-          </li>
-          <li>
-            <%= link_to page_path('moving-guide/civilians'), class: current_page?(id: 'moving-guide/civilians') ? 'usa-current' : nil do %>
-              <i>What to expect…</i> Civilians
-            <% end %>
-          </li>
-          <li>
-            <%= link_to page_path('moving-guide/tips'), class: current_page?(id: 'moving-guide/tips') ? 'usa-current' : nil do %>
-              Tips
-            <% end %>
-          </li>
-          <li>
-            <%= link_to page_path('moving-guide/nightmare-moves'), class: current_page?(id: 'moving-guide/nightmare-moves') ? 'usa-current' : nil do %>
-              Nightmare Moves
-            <% end %>
-          </li>
+          <li><%= active_link_to raw("<i>What to expect…</i> #{abbr_tag('conus')} #{abbr_tag('pcs')}"), page_path('moving-guide/conus'), class_active: 'usa-current' %></li>
+          <li><%= active_link_to raw("<i>What to expect…</i> #{abbr_tag('oconus')} #{abbr_tag('pcs')}"), page_path('moving-guide/oconus'), class_active: 'usa-current' %></li>
+          <li><%= active_link_to raw("<i>What to expect…</i> #{abbr_tag('tdy')}"), page_path('moving-guide/tdy'), class_active: 'usa-current' %></li>
+          <li><%= active_link_to raw('<i>What to expect…</i> Retirees/Separatees'), page_path('moving-guide/retirees-separatees'), class_active: 'usa-current' %></li>
+          <li><%= active_link_to raw('<i>What to expect…</i> Civilians'), page_path('moving-guide/civilians'), class_active: 'usa-current' %></li>
+          <li><%= active_link_to 'Tips', page_path('moving-guide/tips'), class_active: 'usa-current' %></li>
+          <li><%= active_link_to 'Nightmare Moves', page_path('moving-guide/nightmare-moves'), class_active: 'usa-current' %></li>
         </ul>
       <%- end -%>
     </li>
-    <li><%= link_to 'Entitlements', page_path('entitlements'), class: current_page?(id: 'entitlements') ? 'usa-current' : nil %></li>
-    <li><%= link_to 'Tutorials', tutorials_path, class: controller_name == 'tutorials' ? 'usa-current' : nil %></li>
-    <li><%= link_to 'Service-Specific Information', service_specific_information_path, class: controller_name == 'service_specific_information' ? 'usa-current' : nil %></li>
-    <li><%= link_to 'Tools & Resources', page_path('resources'), class: current_page?(id: 'resources') ? 'usa-current' : nil %></li>
+    <li><%= active_link_to 'Entitlements', page_path('entitlements'), class_active: 'usa-current' %></li>
+    <li><%= active_link_to 'Tutorials', tutorials_path, class_active: 'usa-current' %></li>
+    <li><%= active_link_to 'Service-Specific Information', service_specific_information_path, class_active: 'usa-current' %></li>
+    <li><%= active_link_to 'Tools & Resources', page_path('resources'), class_active: 'usa-current' %></li>
   </ul>
 </aside>


### PR DESCRIPTION
Thanks for submitting a pull request! Below are a few things you can do to help us more quickly review your changes.

## Checklist

I have…

- [x] run the application locally (`bin/rails server`) and verified that my changes behave as expected.
- [x] run static code analysis (`bin/rubocop`) and vulnerability scan (`bin/brakeman`) against my changes.
- [x] run the test suite (`bin/rake spec`) and verified that all tests pass.
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.

## Summary of Changes

This pull request adds the [active_link_to](https://github.com/comfy/active_link_to) gem to the project which will simplify the highlighting of "active" navigation items.

## Testing

To verify the changes proposed in this pull request…

1. clone this repo,
1. `git checkout add-active_link_to-gem`,
1. set up development dependencies according to `CONTRIBUTING.md`,
1. `bin/rails server`, and
1. load up http://localhost:3000 in your Web browser of choice.
