### PR TITLE
Some UI polish

### DIFF
--- a/app/assets/stylesheets/components/_header.scss
+++ b/app/assets/stylesheets/components/_header.scss
@@ -27,3 +27,7 @@
     display: inline;
   }
 }
+
+.usa-header {
+  border-bottom: none;
+}

--- a/app/assets/stylesheets/components/_navigation.scss
+++ b/app/assets/stylesheets/components/_navigation.scss
@@ -1,6 +1,5 @@
 .usa-navbar {
   @include padding(1rem 0);
-  border-bottom-color: $color-gray-cool-light;
   height: 6rem;
 
   @include media($nav-width) {
@@ -10,11 +9,16 @@
 
 @include media($nav-width) {
   .usa-header-extended .usa-nav {
-    border-top: 12px solid $color-primary-darkest;
+    border-bottom: 1px solid $color-gray-cool-light;
+    border-top: none;
   }
 
   .usa-nav-secondary {
     top: -7rem;
+  }
+
+  .usa-header-extended .usa-nav-inner {
+    margin-top: 0;
   }
 }
 
@@ -24,4 +28,8 @@
   @include media($nav-width) {
     margin: 0;
   }
+}
+
+.navbar-border {
+  border-top: 12px solid $color-primary-darkest;
 }

--- a/app/assets/stylesheets/components/_section.scss
+++ b/app/assets/stylesheets/components/_section.scss
@@ -56,3 +56,9 @@
     }
   }
 }
+
+@include media($medium-screen) {
+  .usa-section {
+    padding-top: 3rem;
+  }
+}

--- a/app/assets/stylesheets/components/_sidenav.scss
+++ b/app/assets/stylesheets/components/_sidenav.scss
@@ -8,3 +8,11 @@
     width: 100%;
   }
 }
+
+.usa-layout-docs-sidenav {
+  display: none;
+
+  @include media($large-screen) {
+    display: block;
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -59,7 +59,7 @@
     </div>
 
     <div class="usa-navbar">
-      <%= raw('<button class="usa-menu-btn">Menu</button>') if current_page?(root_path) %>
+      <%= raw('<button class="usa-menu-btn">Menu</button>') %>
 
       <div class="usa-logo" id="logo">
         <em class="usa-logo-text">
@@ -71,7 +71,7 @@
       </div>
     </div>
     <div class="navbar-border"></div>
-    <%= render 'shared/nav' if current_page?(root_path) %>
+    <%= render 'shared/nav' %>
   </header>
   <div class="usa-overlay"></div>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -70,7 +70,7 @@
         </em>
       </div>
     </div>
-
+    <div class="navbar-border"></div>
     <%= render 'shared/nav' if current_page?(root_path) %>
   </header>
   <div class="usa-overlay"></div>

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -10,7 +10,7 @@
           <span>Moving with the Military</span>
         </button>
 
-        <ul class="usa-nav-submenu" id="nav-moving-with-the-military">
+        <ul class="usa-nav-submenu" id="nav-moving-with-the-military" aria-hidden="true">
           <li><%= link_to 'Overview', page_path('moving-guide') %></li>
           <li><%= link_to raw("<i>What to expect…</i> #{abbr_tag('conus')} #{abbr_tag('pcs')}"), page_path('moving-guide/conus') %></li>
           <li><%= link_to raw("<i>What to expect…</i> #{abbr_tag('oconus')} #{abbr_tag('pcs')}"), page_path('moving-guide/oconus') %></li>
@@ -41,7 +41,7 @@
           <span>Tools &amp; Resources</span>
         </button>
 
-        <ul class="usa-nav-submenu" id="nav-resources">
+        <ul class="usa-nav-submenu" id="nav-resources" aria-hidden="true">
           <li><%= link_to 'Overview', page_path('resources') %></li>
           <li><%= link_to 'Locator Maps', offices_path %></li>
         </ul>


### PR DESCRIPTION
## Checklist

I have…

- [x] run the application locally (`bin/rails server`) and verified that my changes behave as expected.
- [x] run static code analysis (`bin/rubocop`) and vulnerability scan (`bin/brakeman`) against my changes.
- [x] run the test suite (`bin/rake spec`) and verified that all tests pass.
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.

## Summary of Changes

This pull request…

1. Hides nav bar accordion menus in the html so they dont flash briefly before the javascript runs
2. Makes the thick header bottom border consistent across layouts / pages
3. Hides the sidenav for narrower screens where it appears on the bottom of the page, and always show the top nav.

For issue #99

## Testing

To verify the changes proposed in this pull request…

clone this repo,
git checkout ui_polish,
set up development dependencies according to CONTRIBUTING.md,
run bin/rails server, and
load up http://localhost:3000/ in your Web browser of choice
play with screen size
go to another page
play with screen size

## Screenshots
Header border narrow screen (before):
<img width="440" alt="screen shot 2017-10-03 at 5 36 01 pm" src="https://user-images.githubusercontent.com/29409348/31150912-70c4260a-a863-11e7-8c15-0680ce349169.png">

Header border narrow screen (after):
<img width="437" alt="screen shot 2017-10-03 at 5 35 51 pm" src="https://user-images.githubusercontent.com/29409348/31150933-84a9e934-a863-11e7-9536-153157edab7e.png">

None-homepage header (before):
<img width="1094" alt="screen shot 2017-10-03 at 5 37 04 pm" src="https://user-images.githubusercontent.com/29409348/31150959-9bedaedc-a863-11e7-9be5-3fed6ca1c50c.png">

None-homepage header (after):
<img width="1076" alt="screen shot 2017-10-03 at 5 36 40 pm" src="https://user-images.githubusercontent.com/29409348/31150963-a1b58ccc-a863-11e7-9e46-beccc90d9caa.png">

None-homepage narrow screen (before) -- no menu button + side nav on bottom:
<img width="401" alt="screen shot 2017-10-03 at 5 38 39 pm" src="https://user-images.githubusercontent.com/29409348/31150980-b17186fc-a863-11e7-99af-931b7b9ece93.png">

None-homepage narrow screen (after):
<img width="400" alt="screen shot 2017-10-03 at 5 38 17 pm" src="https://user-images.githubusercontent.com/29409348/31150995-c3d37530-a863-11e7-89d6-e2d4d2f56d1d.png">