### PR TITLE
Update packing estimates and dont use string templates

### DIFF
--- a/app/assets/javascripts/components/weight-estimator.js
+++ b/app/assets/javascripts/components/weight-estimator.js
@@ -61,8 +61,7 @@
             packing_days = '3 days';
           }
           this.$weightResult.html(
-            '<div>Estimated grand total: ' + total + ' lbs</div>' +
-            '<div>Average time to pack ' + total + ' lbs is ' + packing_days + '</div>'
+            '<div>Estimated grand total: ' + total + ' lbs</div><div>Average time to pack ' + total + ' lbs is ' + packing_days + '</div>'
           );
         }
       }

--- a/app/assets/javascripts/components/weight-estimator.js
+++ b/app/assets/javascripts/components/weight-estimator.js
@@ -52,8 +52,17 @@
           $subtotalInput.val(subtotal);
           $totalInput.val(total);
         } else {
+          var packing_days = '4 days';
+          if (total < 5000) {
+            packing_days = '1 day';
+          } else if (total < 7000) {
+            packing_days = '2 days';
+          } else if (total < 9000) {
+            packing_days = '3 days';
+          }
           this.$weightResult.html(
-            `<div>Estimated grand total: ${total} lbs</div><div>Average time to pack ${total} lbs is ${Math.ceil(total/4000)} day(s)</div>`
+            '<div>Estimated grand total: ' + total + ' lbs</div>' +
+            '<div>Average time to pack ' + total + ' lbs is ' + packing_days + '</div>'
           );
         }
       }


### PR DESCRIPTION
## Checklist

I have…

- [x] run the application locally (`bin/rails server`) and verified that my changes behave as expected.
- [x] run static code analysis (`bin/rubocop`) and vulnerability scan (`bin/brakeman`) against my changes.
- [x] run the test suite (`bin/rake spec`) and verified that all tests pass.
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.

## Summary of Changes

This pull request…

1. Removes the back tick used for js string templates. Hoping this unblocks deploy.
2. While I'm at it, update the packing time estimate with new figures from Jill.

## Testing

To verify the changes proposed in this pull request…

1. clone this repo,
2. git checkout remove_backtick
3. set up development dependencies according to CONTRIBUTING.md,
4. run bin/rails server, and
5. load up http://localhost:3000/weight-estimator in your Web browser of choice, calculate some weights

## Screenshots

<img width="400" alt="screen shot 2017-11-01 at 11 55 29 am" src="https://user-images.githubusercontent.com/29409348/32283909-0ce6ed84-befc-11e7-82c7-df70f7a1aa42.png">
