### PR TITLE
Tutorials nav menu + ability to anchor to expanded accordion item

### DIFF
--- a/app/assets/javascripts/components/linkable-accordion.js
+++ b/app/assets/javascripts/components/linkable-accordion.js
@@ -1,0 +1,22 @@
+(function(window, $) {
+  'use strict';
+
+  $(window).on('hashchange', function() {
+    var hash = window.location.hash;
+    var $element = $(hash);
+
+    if ($element.length && $element.hasClass('linkable-accordion-item')) {
+      var $accordion = $element.closest('.linkable-accordion');
+      var $accordionItems = $accordion.find('.linkable-accordion-item');
+
+      $accordionItems.each(function() {
+        var $item = $(this);
+        var shouldExpand = ('#' + $item.attr('id') == hash);
+
+        $item.find('.usa-accordion-button').attr('aria-expanded', shouldExpand);
+        $item.find('.usa-accordion-content').attr('aria-hidden', !shouldExpand);
+      });
+
+    }
+  }).trigger('hashchange');
+})(window, jQuery);

--- a/app/assets/stylesheets/components/_carousel.scss
+++ b/app/assets/stylesheets/components/_carousel.scss
@@ -19,6 +19,7 @@
 
 .carousel-item-content {
   margin: 0;
+  max-width: 92rem;
   padding: 0 3rem;
 
   @include media($nav-width) {

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -24,9 +24,17 @@
         </ul>
       </li>
       <li>
-        <%= link_to tutorials_path, class: 'usa-nav-link' do %>
+        <button aria-controls="nav-tutorials" aria-expanded="false" class="usa-accordion-button usa-nav-link">
           <span>Tutorials</span>
-        <% end %>
+        </button>
+
+        <ul class="usa-nav-submenu" id="nav-tutorials" aria-hidden="true">
+          <li><%= link_to 'Create an Account', tutorials_path(anchor: 'tutorial-1') %></li>
+          <li><%= link_to 'Log In', tutorials_path(anchor: 'tutorial-2') %></li>
+          <li><%= link_to 'Schedule a Move', tutorials_path(anchor: 'tutorial-3') %></li>
+          <li><%= link_to 'File a Claim', tutorials_path(anchor: 'tutorial-4') %></li>
+          <li><%= link_to 'Rate your Transporter (CSS)', tutorials_path(anchor: 'tutorial-5') %></li>
+        </ul>
       </li>
       <li>
         <%= link_to faqs_path, class: 'usa-nav-link' do %>

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -20,7 +20,7 @@
           <li><%= link_to raw("#{abbr_tag('tdy')} Moves"), page_path('moving-guide/tdy') %></li>
           <li><%= link_to raw('Retirees/Separatees'), page_path('moving-guide/retirees-separatees') %></li>
           <li><%= link_to raw("#{abbr_tag('dod')} Civilian Employees"), page_path('moving-guide/civilians') %></li>
-          <li><%= link_to 'Service Specific Info', service_specific_information_path %></li>
+          <li><%= link_to 'Service-Specific Information', service_specific_information_path %></li>
         </ul>
       </li>
       <li>

--- a/app/views/tutorials/index.html.erb
+++ b/app/views/tutorials/index.html.erb
@@ -15,9 +15,9 @@
 
   <h2>How do I…</h2>
 
-  <ul class="usa-accordion-bordered">
+  <ul class="usa-accordion-bordered linkable-accordion">
     <%- @tutorials.each do |tutorial| -%>
-      <li id="tutorial-<%= tutorial.id %>">
+      <li id="tutorial-<%= tutorial.id %>" class="linkable-accordion-item">
         <button aria-controls="<%= tutorial.id %>" class="usa-accordion-button"><%= raw tutorial.title %></button>
         <div class="usa-accordion-content" id="<%= tutorial.id %>">
           <div class="carousel-item-single-page">


### PR DESCRIPTION
## Checklist

I have…

- [x] run the application locally (`bin/rails server`) and verified that my changes behave as expected.
- [x] run static code analysis (`bin/rubocop`) and vulnerability scan (`bin/brakeman`) against my changes.
- [x] run the test suite (`bin/rake spec`) and verified that all tests pass.
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.

## Summary of Changes

- Adds some JS for expanding the anchored accordion item
- Use this to link to tutorial items from the top nav

## Testing

1. clone this repo
2. git checkout tutorials
3. set up development dependencies according to CONTRIBUTING.md,
4. run bin/rails server, and
5. load up http://localhost:3000 in your Web browser of choice, click on tutorial menu items -> anchors to expanded accordion item

## Screenshots

<img width="653" alt="screen shot 2017-11-01 at 4 42 29 pm" src="https://user-images.githubusercontent.com/29409348/32296836-b74f3778-bf23-11e7-8c70-db0e3438d9db.png">
