### PR TITLE
Retirees and Separatees page

### DIFF
--- a/app/assets/images/icons/pro-tip.svg
+++ b/app/assets/images/icons/pro-tip.svg
@@ -1,17 +1,1 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg width="34px" height="44px" viewBox="0 0 34 44" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 47 (45396) - http://www.bohemiancoding.com/sketch -->
-    <title>ProTip</title>
-    <desc>Created with Sketch.</desc>
-    <defs></defs>
-    <g id="What-to-expect---Civilians" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="WhattoExpectRETIREMENT_Desktop" transform="translate(-632.000000, -2021.000000)">
-            <g id="Group-5" transform="translate(621.000000, 2016.000000)">
-                <g id="Group-4" transform="translate(16.000000, 12.000000)" stroke="#0071BC" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <path d="M15.4686804,24 C15.4686804,19.2500304 17.685524,18.0000385 17.685524,18.0000385 C20.7644734,14.8750585 20.9171893,9.96758995 17.840703,6.84260998 C14.7627389,3.71913001 9.77287023,3.71913001 6.69490606,6.84260998 C3.61595662,9.96758995 3.76867251,14.8750585 6.84762195,18.0000385 C6.84762195,18.0000385 9.06446555,19.2500304 9.06446555,24 L15.4686804,24 Z M14.1253355,30 L11.1515806,30 L14.1253355,30 Z M14.8687742,27 L9.66470321,27 L14.8687742,27 Z M11.8950193,0 L11.8950193,1.5 L11.8950193,0 Z M0,12 L1.48687742,12 L0,12 Z M23.7900387,12 L24.5334774,12 L23.7900387,12 Z M2.97375483,21 L3.71719354,20.25 L2.97375483,21 Z M20.0728451,3.75 L20.8162838,3 L20.0728451,3.75 Z M2.97375483,3 L3.71719354,3.75 L2.97375483,3 Z M20.0728451,20.25 L20.8162838,21 L20.0728451,20.25 Z" id="noun_950363"></path>
-                </g>
-                <rect id="Rectangle-7" stroke="#DCE4EF" x="0.5" y="0.5" width="671" height="116"></rect>
-            </g>
-        </g>
-    </g>
-</svg>
+<svg width="34" height="44" viewBox="0 0 34 44" xmlns="http://www.w3.org/2000/svg"><title>ProTip</title><g fill="none" fill-rule="evenodd"><path d="M20.469 31c0-4.75 2.217-6 2.217-6 3.078-3.125 3.231-8.032.155-11.157a7.8 7.8 0 0 0-11.146 0c-3.079 3.125-2.926 8.032.153 11.157 0 0 2.216 1.25 2.216 6h6.405zm-1.344 6h-2.973 2.973zm.744-3h-5.204 5.204zM16.895 7v1.5V7zM5 19h1.487H5zm23.79 0h.743-.743zM7.974 28l.743-.75-.743.75zm17.099-17.25l.743-.75-.743.75zM7.973 10l.744.75-.743-.75zm17.1 17.25l.743.75-.743-.75z" stroke="#0071BC" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/><path stroke="#DCE4EF" d="M-10.5-4.5h671v116h-671z"/></g></svg>

--- a/app/assets/images/icons/pro-tip.svg
+++ b/app/assets/images/icons/pro-tip.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="34px" height="44px" viewBox="0 0 34 44" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 47 (45396) - http://www.bohemiancoding.com/sketch -->
+    <title>ProTip</title>
+    <desc>Created with Sketch.</desc>
+    <defs></defs>
+    <g id="What-to-expect---Civilians" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="WhattoExpectRETIREMENT_Desktop" transform="translate(-632.000000, -2021.000000)">
+            <g id="Group-5" transform="translate(621.000000, 2016.000000)">
+                <g id="Group-4" transform="translate(16.000000, 12.000000)" stroke="#0071BC" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M15.4686804,24 C15.4686804,19.2500304 17.685524,18.0000385 17.685524,18.0000385 C20.7644734,14.8750585 20.9171893,9.96758995 17.840703,6.84260998 C14.7627389,3.71913001 9.77287023,3.71913001 6.69490606,6.84260998 C3.61595662,9.96758995 3.76867251,14.8750585 6.84762195,18.0000385 C6.84762195,18.0000385 9.06446555,19.2500304 9.06446555,24 L15.4686804,24 Z M14.1253355,30 L11.1515806,30 L14.1253355,30 Z M14.8687742,27 L9.66470321,27 L14.8687742,27 Z M11.8950193,0 L11.8950193,1.5 L11.8950193,0 Z M0,12 L1.48687742,12 L0,12 Z M23.7900387,12 L24.5334774,12 L23.7900387,12 Z M2.97375483,21 L3.71719354,20.25 L2.97375483,21 Z M20.0728451,3.75 L20.8162838,3 L20.0728451,3.75 Z M2.97375483,3 L3.71719354,3.75 L2.97375483,3 Z M20.0728451,20.25 L20.8162838,21 L20.0728451,20.25 Z" id="noun_950363"></path>
+                </g>
+                <rect id="Rectangle-7" stroke="#DCE4EF" x="0.5" y="0.5" width="671" height="116"></rect>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/app/assets/stylesheets/components/_layout.scss
+++ b/app/assets/stylesheets/components/_layout.scss
@@ -20,8 +20,12 @@
     border-bottom: 0.25rem solid $color-primary-darker;
     color: $color-primary-darker;
     font-family: $font-sans;
-    font-size: $h1-font-size;
+    font-size: $h2-font-size;
     padding-bottom: 2.5rem;
+
+    @include media($medium-screen) {
+      font-size: $h1-font-size;
+    }
   }
 
   h2 {

--- a/app/assets/stylesheets/components/_what_to_expect.scss
+++ b/app/assets/stylesheets/components/_what_to_expect.scss
@@ -26,12 +26,6 @@
   }
 }
 
-.branch-of-service-links {
-  a + a {
-    margin-left: 3rem;
-  }
-}
-
 .pro-tip {
   border: solid 1px $color-gray-cool-light;
   margin-top: 2rem;

--- a/app/assets/stylesheets/components/_what_to_expect.scss
+++ b/app/assets/stylesheets/components/_what_to_expect.scss
@@ -1,0 +1,40 @@
+.what-to-expect-body {
+  .what-to-expect-intro {
+    background-color: $color-gray-cool-light;
+    @include margin(2rem 0);
+    @include padding($site-margins-mobile);
+
+    @include media($medium-screen) {
+      @include padding($site-margins);
+    }
+  }
+
+  h3 {
+    color: $color-primary-darkest;
+  }
+}
+
+.what-to-expect-section {
+  @include padding(2rem 0);
+
+  & + & {
+    border-top: 1px solid $color-gray-cool-light;
+  }
+
+  h4 {
+    font-size: 1.8rem;
+  }
+}
+
+.branch-of-service-links {
+  a + a {
+    white-space: nowrap;
+    margin-left: 3rem;
+  }
+}
+
+.pro-tip {
+  border: solid 1px $color-gray-cool-light;
+  margin-top: 2rem;
+  padding: 1rem;
+}

--- a/app/assets/stylesheets/components/_what_to_expect.scss
+++ b/app/assets/stylesheets/components/_what_to_expect.scss
@@ -28,7 +28,6 @@
 
 .branch-of-service-links {
   a + a {
-    white-space: nowrap;
     margin-left: 3rem;
   }
 }

--- a/app/assets/stylesheets/elements/_list.scss
+++ b/app/assets/stylesheets/elements/_list.scss
@@ -85,14 +85,12 @@
   }
 }
 
-.service-links-list {
-  li {
-    float: left;
-    width: 50%;
+.service-links-list li {
+  float: left;
+  width: 50%;
 
-    @include media($medium-screen) {
-      width: auto;
-      margin-right: 3rem;
-    }
+  @include media($medium-screen) {
+    width: auto;
+    margin-right: 3rem;
   }
 }

--- a/app/assets/stylesheets/elements/_list.scss
+++ b/app/assets/stylesheets/elements/_list.scss
@@ -80,7 +80,19 @@
 
     @include media($medium-screen) {
       height: 8rem;
-      max-width: 50%
+      max-width: 50%;
+    }
+  }
+}
+
+.service-links-list {
+  li {
+    float: left;
+    width: 50%;
+
+    @include media($medium-screen) {
+      width: auto;
+      margin-right: 3rem;
     }
   }
 }

--- a/app/assets/stylesheets/elements/_typography.scss
+++ b/app/assets/stylesheets/elements/_typography.scss
@@ -1,3 +1,7 @@
 abbr[title] {
   text-decoration: none;
 }
+
+.centered {
+  text-align: center;
+}

--- a/app/views/pages/moving-guide/retirees-separatees.html.erb
+++ b/app/views/pages/moving-guide/retirees-separatees.html.erb
@@ -40,7 +40,7 @@
         <p><strong>For separatees with less than 8 years of continuous active duty:</strong> The government will only pay the cost of moving your belongings to your Home of Record (HOR) or your Place Entering Active Duty (PLEAD).<p>
         <p>You can still move somewhere else, however you will be responsible any additional costs above what it would have cost to move your entire weight allowance to your Home of Record (HOR) or to your Place Entering Active Duty (PLEAD).</p>
         <p><strong>For retirees or separatees with more than 8 years of continuous active duty:</strong> The government will cover the cost of relocating you to your Home of Selection (HOS), anywhere within the United States.</p>
-        <p>You can still move outside the United States, however you will be responsible for any additional costs above what it would have cost to move you within the contiguous 48-states. To determine the government cost, the Personal Property Office typically uses the cost of transporting your entire weight allowance to the farthest possible location within the 48-contiguous states from your current station to calculate the government’s maximum liability.</p>
+        <p>You can still move outside the United States, however you will be responsible for any additional costs above what it would have cost to move you within the contiguous 48-states. To determine the government cost, the Personal Property Office typically uses the cost of transporting your entire weight allowance to the farthest possible location within the 48-contiguous states from your current station to calculate the government's maximum liability.</p>
       </div>
     </div>
 
@@ -90,7 +90,7 @@
 
         <p><strong>Long term storage (NTS) at origin</strong> (the location where you were last stationed) for up to 180 days. If you have not scheduled your delivery before your 180 days expires, you will be personally responsible for any additional storage costs.</p>
         <div class="centered">OR</div>
-        <p><strong>Short term storage (SIT)</strong> at your destination up to 90 days. If your household goods aren’t delivered before the 90 days expires, you will be responsible for the very expensive excess storage costs and you will be ineligible to file any claims within the government Military Claims Office.</p>
+        <p><strong>Short term storage (SIT)</strong> at your destination up to 90 days. If your household goods aren't delivered before the 90 days expires, you will be responsible for the very expensive excess storage costs and you will be ineligible to file any claims within the government Military Claims Office.</p>
 
         <div class="usa-media_block pro-tip">
           <%= image_tag 'icons/pro-tip.svg', alt: 'lightbulb icon', class: 'usa-media_block-img' %>

--- a/app/views/pages/moving-guide/retirees-separatees.html.erb
+++ b/app/views/pages/moving-guide/retirees-separatees.html.erb
@@ -27,7 +27,7 @@
 
   <div class="usa-width-three-fourths what-to-expect-body">
     <div class="what-to-expect-intro">
-      At this point in your career, you are probably well versed in the PCS process - making you wonder what the big differences are for this final move. It is  recommended that you reach out to your <%= link_to 'local personal property office', offices_path %> for help arranging your move.
+      At this point in your career, you are probably well versed in the <%= abbr_tag('pcs') %> process - making you wonder what the big differences are for this final move. It is  recommended that you reach out to your <%= link_to 'local personal property office', offices_path %> for help arranging your move.
     </div>
 
     <h3>What is different about a retiree or separatee move?</h3>
@@ -59,7 +59,7 @@
         <h4>Extensions<h4>
       </div>
       <div class="usa-width-three-fourths">
-        <p>If you cannot make your separation or retirement move within the designated time frame, you can request an extension (usually via email) from your branch of service. <strong>Time limit extensions can not extend the amount of time you can use NTS or SIT.</strong></p>
+        <p>If you cannot make your separation or retirement move within the designated time frame, you can request an extension (usually via email) from your branch of service. <strong>Time limit extensions can not extend the amount of time you can use <%= abbr_tag('nts') %> or <%= abbr_tag('sit') %>.</strong></p>
 
         <p><strong>Extensions are granted for the following reasons (extensions cannot be granted for convenience or personal preferences):</strong></p>
         <ul>
@@ -86,7 +86,7 @@
         <h4>Storage Options<h4>
       </div>
       <div class="usa-width-three-fourths">
-        <p>Unlike some PCS Moves, <strong>you are only allowed ONE of the following options:</strong></p>
+        <p>Unlike some <%= abbr_tag('pcs') %> Moves, <strong>you are only allowed ONE of the following options:</strong></p>
 
         <p><strong>Long term storage (NTS) at origin</strong> (the location where you were last stationed) for up to 180 days. If you have not scheduled your delivery before your 180 days expires, you will be personally responsible for any additional storage costs.</p>
         <div class="centered">OR</div>
@@ -94,22 +94,22 @@
 
         <div class="usa-media_block pro-tip">
           <%= image_tag 'icons/pro-tip.svg', alt: 'lightbulb icon', class: 'usa-media_block-img' %>
-          <div class="usa-media_block-body"><strong>Pro-Tip:</strong> It is recommended that you only use Short term storage (SIT), if you know your final delivery address upon retirement. If for some reason, you cannot secure housing or a place to deliver your household goods, you will be responsible for any additional storage cost beyond the initial 90 days. Additional storage costs can be very expensive - sometimes thousands dollars a month.</div>
+          <div class="usa-media_block-body"><strong>Pro-Tip:</strong> It is recommended that you only use short term storage (SIT), if you know your final delivery address upon retirement. If for some reason, you cannot secure housing or a place to deliver your household goods, you will be responsible for any additional storage cost beyond the initial 90 days. Additional storage costs can be very expensive - sometimes thousands dollars a month.</div>
         </div>
       </div>
     </div>
 
     <div id="payments" class="what-to-expect-section usa-grid">
       <div class="usa-width-one-fourth">
-        <h4>Advance Payment for PPM “Do-it-Yourself” Moves<h4>
+        <h4>Advance Payment for <%= abbr_tag('ppm') %> “Do-it-Yourself” Moves<h4>
       </div>
       <div class="usa-width-three-fourths">
-        <p>Advances for PPM “Do-it Yourself” moves may be limited by your branch of service for retiree/separtee moves.<p>
-        <p><strong>Army:</strong> No advance payment is made for Separatees. Retirees can recieve an advance of up to 60% of the 95% PPM incentive payment.</p>
-        <p><strong>Marines:</strong> Marine Retirees and Separatees can recieve an advancement of up to 60% of the 95% PPM incentive payment. To receive your advancement, you must complete a <%= link_to 'detailed weight estimation', weight_estimator_path %> and reach out to your <%= link_to 'local Personal Property Office (PPPO)', offices_path %> to arrange for a local quality assurance inspector to visit your residence to verify your estimated weight.</p>
-        <p><strong>Navy:</strong> No advance payment is given for Separatee/Retiree moves.</p>
-        <p><strong>Air Force:</strong> Air Force Retirees and Separtees can receive an advancement of up to 60% of the 95% PPM incentive payment. </p>
-        <p><strong>Coast Guard:</strong> Retirees and Separatees still on active duty are authorized an advance NTE written estimate from rental company for costs of truck, equipment etc. up to 60% of the 95% incentive payment. Separatees whose active duty termination date have past cannot receive advance payment for PPM Moves.</p>
+        <p>Advances for <%= abbr_tag('ppm') %> “Do-it Yourself” moves may be limited by your branch of service for retiree/separtee moves.<p>
+        <p><strong>Army:</strong> No advance payment is made for separatees. Retirees can recieve an advance of up to 60% of the 95% <%= abbr_tag('ppm') %> incentive payment.</p>
+        <p><strong>Marines:</strong> Marine retirees and separatees can recieve an advancement of up to 60% of the 95% <%= abbr_tag('ppm') %> incentive payment. To receive your advancement, you must complete a <%= link_to 'detailed weight estimation', weight_estimator_path %> and reach out to your <%= link_to 'local personal property office (PPPO)', offices_path %> to arrange for a local quality assurance inspector to visit your residence to verify your estimated weight.</p>
+        <p><strong>Navy:</strong> No advance payment is given for separatee/retiree moves.</p>
+        <p><strong>Air Force:</strong> Air Force retirees and separatees can receive an advancement of up to 60% of the 95% <%= abbr_tag('ppm') %> incentive payment. </p>
+        <p><strong>Coast Guard:</strong> Retirees and separatees still on active duty are authorized an advance <%= abbr_tag('nte') %> written estimate from rental company for costs of truck, equipment etc. up to 60% of the 95% incentive payment. Separatees whose active duty termination date have past cannot receive advance payment for <%= abbr_tag('ppm') %> moves.</p>
       </div>
     </div>
 
@@ -118,11 +118,11 @@
         <h4>Short Distance Moves<h4>
       </div>
       <div class="usa-width-three-fourths">
-        <p>If you were living on base, and your housing agreement requires you to move out of government quarters before you can determine your home of selection (HOS) you are authorized a short distance HHG move from the government quarters to a local temporary residence in the vicinity of the vacated quarters. You must obtain a memo from the garrison housing office providing the funding citation to be used for the move. The JFTR weight limit does not apply to this “local move” out of government quarters. This local move does not count as your retirement move, unless you use your retirement orders for the move. <strong>Local moves must take place within a 30-mile radius from your base.</strong></p>
+        <p>If you were living on base, and your housing agreement requires you to move out of government quarters before you can determine your Home of Selection (HOS) you are authorized a short distance <%= abbr_tag('hhg') %> move from the government quarters to a local temporary residence in the vicinity of the vacated quarters. You must obtain a memo from the garrison housing office providing the funding citation to be used for the move. The usual rank-based weight limits do not apply to this "local move" out of government quarters. This local move does not count as your retirement move, unless you use your retirement orders for the move. <strong>Local moves must take place within a 30-mile radius from your base.</strong></p>
       </div>
     </div>
 
-    <h3>What is the same between a PCS and a retiree or separatee move?</h3>
+    <h3>What is the same between a <%= abbr_tag('pcs') %> and a retiree or separatee move?</h3>
 
     <div id="weight" class="what-to-expect-section usa-grid">
       <div class="usa-width-one-fourth">
@@ -138,7 +138,7 @@
         <h4>Personally-Owned Vehicles (POV)<h4>
       </div>
       <div class="usa-width-three-fourths">
-        <p>You are required to drive or ship your primary vehicles (POVs) primarily at your own expense as with any CONUS Permanent Change of Station (PCS). In some cases, a POV shipment can requested and authorized if the service member physically cannot drive their car because of geographical or medical limitations.</p>
+        <p>You are required to drive or ship your primary vehicles (POVs) primarily at your own expense as with any CONUS Permanent Change of Station (PCS). In some cases, a <%= abbr_tag('pov') %> shipment can requested and authorized if the service member physically cannot drive their car because of geographical or medical limitations.</p>
       </div>
     </div>
 

--- a/app/views/pages/moving-guide/retirees-separatees.html.erb
+++ b/app/views/pages/moving-guide/retirees-separatees.html.erb
@@ -105,13 +105,11 @@
       </div>
       <div class="usa-width-three-fourths">
         <p>Advances for PPM “Do-it Yourself” moves may be limited by your branch of service for retiree/separtee moves.<p>
-        <ul class="usa-unstyled-list">
-          <li>Army:</li>
-          <li>Marines:</li>
-          <li>Navy: No advance payment is given for Separatee/Retiree moves</li>
-          <li>Air Force:</li>
-          <li>Coast Guard:</li>
-        </ul>
+        <p><strong>Army:</strong> No advance payment is made for Separatees. Retirees can recieve an advance of up to 60% of the 95% PPM incentive payment.</p>
+        <p><strong>Marines:</strong> Marine Retirees and Separatees can recieve an advancement of up to 60% of the 95% PPM incentive payment. To receive your advancement, you must complete a <%= link_to 'detailed weight estimation', weight_estimator_path %> and reach out to your <%= link_to 'local Personal Property Office (PPPO)', offices_path %> to arrange for a local quality assurance inspector to visit your residence to verify your estimated weight.</p>
+        <p><strong>Navy:</strong> No advance payment is given for Separatee/Retiree moves.</p>
+        <p><strong>Air Force:</strong> Air Force Retirees and Separtees can receive an advancement of up to 60% of the 95% PPM incentive payment. </p>
+        <p><strong>Coast Guard:</strong> Retirees and Separatees still on active duty are authorized an advance NTE written estimate from rental company for costs of truck, equipment etc. up to 60% of the 95% incentive payment. Separatees whose active duty termination date have past cannot receive advance payment for PPM Moves.</p>
       </div>
     </div>
 
@@ -120,7 +118,7 @@
         <h4>Short Distance Moves<h4>
       </div>
       <div class="usa-width-three-fourths">
-        <p>If you were living on base and you need to vacate government quarters before selecting your home (HOS), you are authorized a short distance HHG move from the government quarters to a local temporary residence in the vicinity of the vacated quarters. You must obtain a memo from the garrison housing office providing the funding citation to be used for the move. The JFTR weight limit does not apply to this “local move” out of government quarters. This local move must take place within a 30-mile radius from your base, and it does not count as your retirement move, unless you use your retirement orders for the move.</p>
+        <p>If you were living on base, and your housing agreement requires you to move out of government quarters before you can determine your home of selection (HOS) you are authorized a short distance HHG move from the government quarters to a local temporary residence in the vicinity of the vacated quarters. You must obtain a memo from the garrison housing office providing the funding citation to be used for the move. The JFTR weight limit does not apply to this “local move” out of government quarters. This local move does not count as your retirement move, unless you use your retirement orders for the move. <strong>Local moves must take place within a 30-mile radius from your base.</strong></p>
       </div>
     </div>
 

--- a/app/views/pages/moving-guide/retirees-separatees.html.erb
+++ b/app/views/pages/moving-guide/retirees-separatees.html.erb
@@ -37,9 +37,9 @@
         <h4>Destination<h4>
       </div>
       <div class="usa-width-three-fourths">
-        <p><strong>For Separatees with Less than 8 years of Continuous Active Duty:</strong> The Government will only pay the cost of moving your belongings to your Home of Record (HOR) or your Place Entering Active Duty (PLEAD).<p>
+        <p><strong>For separatees with less than 8 years of continuous active duty:</strong> The government will only pay the cost of moving your belongings to your Home of Record (HOR) or your Place Entering Active Duty (PLEAD).<p>
         <p>You can still move somewhere else, however you will be responsible any additional costs above what it would have cost to move your entire weight allowance to your Home of Record (HOR) or to your Place Entering Active Duty (PLEAD).</p>
-        <p><strong>For Retirees or Separatees with Over than 8 years of Continuous Active Duty:</strong> The Government will cover the cost of relocating you to your Home of Selection (HOS), anywhere within the United States.</p>
+        <p><strong>For retirees or separatees with more than 8 years of continuous active duty:</strong> The government will cover the cost of relocating you to your Home of Selection (HOS), anywhere within the United States.</p>
         <p>You can still move outside the United States, however you will be responsible for any additional costs above what it would have cost to move you within the contiguous 48-states. To determine the government cost, the Personal Property Office typically uses the cost of transporting your entire weight allowance to the farthest possible location within the 48-contiguous states from your current station to calculate the government’s maximum liability.</p>
       </div>
     </div>
@@ -49,8 +49,8 @@
         <h4>Timing<h4>
       </div>
       <div class="usa-width-three-fourths">
-        <p><strong>For Separatees with Less than 8 years of Continuous Active Duty:</strong> Your move must be scheduled within 180 days from your active duty termination date.<p>
-        <p><strong>For Retirees or Separatees with Over than 8 years of Continuous Active Duty:</strong> Your move must be scheduled within 1 year from your active duty termination date.</p>
+        <p><strong>For separatees with less than 8 years of continuous active duty:</strong> Your move must be scheduled within 180 days from your active duty termination date.<p>
+        <p><strong>For retirees or separatees with more than 8 years of continuous active duty:</strong> Your move must be scheduled within 1 year from your active duty termination date.</p>
       </div>
     </div>
 
@@ -61,14 +61,14 @@
       <div class="usa-width-three-fourths">
         <p>If you cannot make your separation or retirement move within the designated time frame, you can request an extension (usually via email) from your branch of service. <strong>Time limit extensions can not extend the amount of time you can use NTS or SIT.</strong></p>
 
-        <p><strong>Extensions are granted for the following reasons. (Extensions  cannot be granted for convenience or personal preferences):</strong></p>
+        <p><strong>Extensions are granted for the following reasons (extensions cannot be granted for convenience or personal preferences):</strong></p>
         <ul>
-          <li>Medical Treatment: The service member is undergoing hospitalization or receiving medical treatment.</li>
-          <li>Education of Training: The service member is undergoing education or training.</li>
+          <li>Medical treatment: The service member is undergoing hospitalization or receiving medical treatment.</li>
+          <li>Education or training: The service member is undergoing education or training.</li>
           <li>Other worthy causes: Specific hardship situations, legal or administrative proceedings that preclude the service member from moving within the time limit, unexpected events such as delay in selling/renovating/construction of a new home, or any delay necessitated as a result of separating/retirement from the service.</li>
         </ul>
 
-        <p>Each branch of service has slight variations regarding the process and maximum amount of time that can extensions can be granted for.  Generally, separatees with less than 8 years of service can request extensions in 180-day intervals, for no longer than 3 years, while retirees and separatees with over 8 years of experience can request annual (1 -year) extensions, for up to 6 years.</p>
+        <p>Each branch of service has slight variations regarding the process and maximum amount of time that extensions can be granted for. Generally, separatees with less than 8 years of service can request extensions in 180-day intervals, for no longer than 3 years, while retirees and separatees with over 8 years of experience can request annual (1-year) extensions, for up to 6 years.</p>
 
         <p>Select your branch of service to check the specific requirements:</p>
         <ul class="usa-unstyled-list service-links-list">
@@ -86,7 +86,7 @@
         <h4>Storage Options<h4>
       </div>
       <div class="usa-width-three-fourths">
-        <p>Unlike some PCS Moves, <strong>you are only allowed ONE of the following options</strong>:</p>
+        <p>Unlike some PCS Moves, <strong>you are only allowed ONE of the following options:</strong></p>
 
         <p><strong>Long term storage (NTS) at origin</strong> (the location where you were last stationed) for up to 180 days. If you have not scheduled your delivery before your 180 days expires, you will be personally responsible for any additional storage costs.</p>
         <div class="centered">OR</div>
@@ -120,13 +120,11 @@
         <h4>Short Distance Moves<h4>
       </div>
       <div class="usa-width-three-fourths">
-        <p>If you were living on base, and your housing … Local moves must take place within a 30-mile radius from your base.</p>
-
-        <p>If you are required to vacate government quarters before selecting your home (HOS), you are authorized a short distance HHG move from the government quarters to a local temporary residence in the vicinity of the vacated quarters. You must obtain a memo from the garrison housing office providing the funding citation to be used for the move. The JFTR weight limit does not apply to this “local move” out of government quarters. This local move does not count as your retirement move, unless you use your retirement orders for the move.</p>
+        <p>If you were living on base and you need to vacate government quarters before selecting your home (HOS), you are authorized a short distance HHG move from the government quarters to a local temporary residence in the vicinity of the vacated quarters. You must obtain a memo from the garrison housing office providing the funding citation to be used for the move. The JFTR weight limit does not apply to this “local move” out of government quarters. This local move must take place within a 30-mile radius from your base, and it does not count as your retirement move, unless you use your retirement orders for the move.</p>
       </div>
     </div>
 
-    <h3>What is the same between a PCS and a retirees or separatee move?</h3>
+    <h3>What is the same between a PCS and a retiree or separatee move?</h3>
 
     <div id="weight" class="what-to-expect-section usa-grid">
       <div class="usa-width-one-fourth">
@@ -142,7 +140,7 @@
         <h4>Personally-Owned Vehicles (POV)<h4>
       </div>
       <div class="usa-width-three-fourths">
-        <p>You are required to drive or ship your primary vehicles (POVs) primarily at your own expense as with any CONUS Permanent Change of Station (PCS). (In some cases, a POV shipment can requested and authorized if the service member physically cannot drive their car because of geographical or medical limitations.)</p>
+        <p>You are required to drive or ship your primary vehicles (POVs) primarily at your own expense as with any CONUS Permanent Change of Station (PCS). In some cases, a POV shipment can requested and authorized if the service member physically cannot drive their car because of geographical or medical limitations.</p>
       </div>
     </div>
 

--- a/app/views/pages/moving-guide/retirees-separatees.html.erb
+++ b/app/views/pages/moving-guide/retirees-separatees.html.erb
@@ -1,11 +1,167 @@
-<%- @page_title = 'What to expect… Retirees/Separatees' -%>
+<%- @page_title = 'Retiree and Separatee Moves' -%>
 
 <%= render partial: 'shared/contextual_header', locals: {page_title: @page_title, parent_pages: []} %>
 
 <div class="usa-section main-section">
   <h1><%= @page_title %></h1>
 
-  <%# TODO Add page content %>
+  <div class="usa-width-one-fourth">
+    <aside class="sidenav">
+      <div class="sidenav-jump-to">
+        Jump to:
+      </div>
+      <ul class="usa-sidenav-list">
+        <li><%= link_to 'Destination', '#destination' %></li>
+        <li><%= link_to 'Timing', '#timing' %></li>
+        <li><%= link_to 'Extensions', '#extensions' %></li>
+        <li><%= link_to 'Storage Options', '#storage' %></li>
+        <li><%= link_to 'Advance Payments', '#payments' %></li>
+        <li><%= link_to 'Short Distance Moves', '#short-distance' %></li>
+        <li><%= link_to 'Weight Entitlements', '#weight' %></li>
+        <li><%= link_to 'Personally Owned Vehicles (POV)', '#pov' %></li>
+        <li><%= link_to 'Pro Gear', '#pro-gear' %></li>
+        <li><%= link_to 'Shipping Methods', '#shipping' %></li>
+      </ul>
+    </aside>
+  </div>
 
-  <p>Coming soon!</p>
+  <div class="usa-width-three-fourths what-to-expect-body">
+    <div class="what-to-expect-intro">
+      At this point in your career, you are probably well versed in the PCS process - making you wonder what the big differences are for this final move. It is  recommended that you reach out to your <%= link_to 'local personal property office', offices_path %> for help arranging your move.
+    </div>
+
+    <h3>What is different about a retiree or separatee move?</h3>
+
+    <div id="destination" class="what-to-expect-section usa-grid">
+      <div class="usa-width-one-fourth">
+        <h4>Destination<h4>
+      </div>
+      <div class="usa-width-three-fourths">
+        <p><strong>For Separatees with Less than 8 years of Continuous Active Duty:</strong> The Government will only pay the cost of moving your belongings to your Home of Record (HOR) or your Place Entering Active Duty (PLEAD).<p>
+        <p>You can still move somewhere else, however you will be responsible any additional costs above what it would have cost to move your entire weight allowance to your Home of Record (HOR) or to your Place Entering Active Duty (PLEAD).</p>
+        <p><strong>For Retirees or Separatees with Over than 8 years of Continuous Active Duty:</strong> The Government will cover the cost of relocating you to your Home of Selection (HOS), anywhere within the United States.</p>
+        <p>You can still move outside the United States, however you will be responsible for any additional costs above what it would have cost to move you within the contiguous 48-states. To determine the government cost, the Personal Property Office typically uses the cost of transporting your entire weight allowance to the farthest possible location within the 48-contiguous states from your current station to calculate the government’s maximum liability.</p>
+      </div>
+    </div>
+
+    <div id="timing" class="what-to-expect-section usa-grid">
+      <div class="usa-width-one-fourth">
+        <h4>Timing<h4>
+      </div>
+      <div class="usa-width-three-fourths">
+        <p><strong>For Separatees with Less than 8 years of Continuous Active Duty:</strong> Your move must be scheduled within 180 days from your active duty termination date.<p>
+        <p><strong>For Retirees or Separatees with Over than 8 years of Continuous Active Duty:</strong> Your move must be scheduled within 1 year from your active duty termination date.</p>
+      </div>
+    </div>
+
+    <div id="extensions" class="what-to-expect-section usa-grid">
+      <div class="usa-width-one-fourth">
+        <h4>Extensions<h4>
+      </div>
+      <div class="usa-width-three-fourths">
+        <p>If you cannot make your separation or retirement move within the designated time frame, you can request an extension (usually via email) from your branch of service. <strong>Time limit extensions can not extend the amount of time you can use NTS or SIT.</strong></p>
+
+        <p><strong>Extensions are granted for the following reasons. (Extensions  cannot be granted for convenience or personal preferences):</strong></p>
+        <ul>
+          <li>Medical Treatment: The service member is undergoing hospitalization or receiving medical treatment.</li>
+          <li>Education of Training: The service member is undergoing education or training.</li>
+          <li>Other worthy causes: Specific hardship situations, legal or administrative proceedings that preclude the service member from moving within the time limit, unexpected events such as delay in selling/renovating/construction of a new home, or any delay necessitated as a result of separating/retirement from the service.</li>
+        </ul>
+
+        <p>Each branch of service has slight variations regarding the process and maximum amount of time that can extensions can be granted for.  Generally, separatees with less than 8 years of service can request extensions in 180-day intervals, for no longer than 3 years, while retirees and separatees with over 8 years of experience can request annual (1 -year) extensions, for up to 6 years.</p>
+
+        <p>Select your branch of service to check the specific requirements:</p>
+        <ul class="usa-unstyled-list service-links-list">
+          <li><%= link_to 'Army', service_specific_information_path(anchor: 'army'), class: 'usa-width-one-sixth'%></li>
+          <li><%= link_to 'Marine Corps', service_specific_information_path(anchor: 'marines') %></li>
+          <li><%= link_to 'Navy', service_specific_information_path(anchor: 'navy') %></li>
+          <li><%= link_to 'Air Force', service_specific_information_path(anchor: 'air-force') %></li>
+          <li><%= link_to 'Coast Guard', service_specific_information_path(anchor: 'coast-guard') %></li>
+        </ul>
+      </div>
+    </div>
+
+    <div id="storage" class="what-to-expect-section usa-grid">
+      <div class="usa-width-one-fourth">
+        <h4>Storage Options<h4>
+      </div>
+      <div class="usa-width-three-fourths">
+        <p>Unlike some PCS Moves, <strong>you are only allowed ONE of the following options</strong>:</p>
+
+        <p><strong>Long term storage (NTS) at origin</strong> (the location where you were last stationed) for up to 180 days. If you have not scheduled your delivery before your 180 days expires, you will be personally responsible for any additional storage costs.</p>
+        <div class="centered">OR</div>
+        <p><strong>Short term storage (SIT)</strong> at your destination up to 90 days. If your household goods aren’t delivered before the 90 days expires, you will be responsible for the very expensive excess storage costs and you will be ineligible to file any claims within the government Military Claims Office.</p>
+
+        <div class="usa-media_block pro-tip">
+          <%= image_tag 'icons/pro-tip.svg', alt: 'lightbulb icon', class: 'usa-media_block-img' %>
+          <div class="usa-media_block-body"><strong>Pro-Tip:</strong> It is recommended that you only use Short term storage (SIT), if you know your final delivery address upon retirement. If for some reason, you cannot secure housing or a place to deliver your household goods, you will be responsible for any additional storage cost beyond the initial 90 days. Additional storage costs can be very expensive - sometimes thousands dollars a month.</div>
+        </div>
+      </div>
+    </div>
+
+    <div id="payments" class="what-to-expect-section usa-grid">
+      <div class="usa-width-one-fourth">
+        <h4>Advance Payment for PPM “Do-it-Yourself” Moves<h4>
+      </div>
+      <div class="usa-width-three-fourths">
+        <p>Advances for PPM “Do-it Yourself” moves may be limited by your branch of service for retiree/separtee moves.<p>
+        <ul class="usa-unstyled-list">
+          <li>Army:</li>
+          <li>Marines:</li>
+          <li>Navy: No advance payment is given for Separatee/Retiree moves</li>
+          <li>Air Force:</li>
+          <li>Coast Guard:</li>
+        </ul>
+      </div>
+    </div>
+
+    <div id="short-distance" class="what-to-expect-section usa-grid">
+      <div class="usa-width-one-fourth">
+        <h4>Short Distance Moves<h4>
+      </div>
+      <div class="usa-width-three-fourths">
+        <p>If you were living on base, and your housing … Local moves must take place within a 30-mile radius from your base.</p>
+
+        <p>If you are required to vacate government quarters before selecting your home (HOS), you are authorized a short distance HHG move from the government quarters to a local temporary residence in the vicinity of the vacated quarters. You must obtain a memo from the garrison housing office providing the funding citation to be used for the move. The JFTR weight limit does not apply to this “local move” out of government quarters. This local move does not count as your retirement move, unless you use your retirement orders for the move.</p>
+      </div>
+    </div>
+
+    <h3>What is the same between a PCS and a retirees or separatee move?</h3>
+
+    <div id="weight" class="what-to-expect-section usa-grid">
+      <div class="usa-width-one-fourth">
+        <h4>Weight Entitlements<h4>
+      </div>
+      <div class="usa-width-three-fourths">
+        <p>The amount of household goods you are allowed to move is still dependent on your final rank upon exiting military service. <%= link_to 'Determine your weight entitlement.', page_path('entitlements') %></p>
+      </div>
+    </div>
+
+    <div id="pov" class="what-to-expect-section usa-grid">
+      <div class="usa-width-one-fourth">
+        <h4>Personally-Owned Vehicles (POV)<h4>
+      </div>
+      <div class="usa-width-three-fourths">
+        <p>You are required to drive or ship your primary vehicles (POVs) primarily at your own expense as with any CONUS Permanent Change of Station (PCS). (In some cases, a POV shipment can requested and authorized if the service member physically cannot drive their car because of geographical or medical limitations.)</p>
+      </div>
+    </div>
+
+    <div id="pro-gear" class="what-to-expect-section usa-grid">
+      <div class="usa-width-one-fourth">
+        <h4>Pro Gear<h4>
+      </div>
+      <div class="usa-width-three-fourths">
+        <p>You and your spouse (if applicable) are allowed to move Pro-Gear that was related to your professional duties. Just like with your past active duty PCS moves, you can move up to 2,000 lbs of professional gear, and your spouse can move up to 500 lbs of professional gear.</p>
+      </div>
+    </div>
+
+    <div id="shipping" class="what-to-expect-section usa-grid">
+      <div class="usa-width-one-fourth">
+        <h4>Shipping Methods<h4>
+      </div>
+      <div class="usa-width-three-fourths">
+        <p>You are allowed to have the government coordinate a move of your household goods with a “Household Goods Move” (HHG), to coordinate your own move with a Personally-Procured “Do-It-Yourself” Move (PPM), or a combination of both options. Use the <%= link_to 'PPM Estimator', '#TODO' %> to estimate the government incentive cost of doing a Personally-Procured Move.</p>
+      </div>
+    </div>
+  </div>
 </div>

--- a/app/views/pages/moving-guide/tdy.html.erb
+++ b/app/views/pages/moving-guide/tdy.html.erb
@@ -25,9 +25,9 @@
     </div>
     <div id="weight_allowances">
       <h4>Weight Allowances for <%= abbr_tag('tdy') %> Shipments</h4>
-      <p>The member’s grade on the day travel begins determines which weight allowance is allowed.  The weight allowances below are in addition to any unaccompanied or accompanied baggage.  Furthermore, in the event the <%= abbr_tag('tdy') %> location becomes the permanent duty station, this would mean that the <%= abbr_tag('tdy') %> weight allowance would also be an additional allowance to any PCS weight entitlements.</p>
+      <p>The member's grade on the day travel begins determines which weight allowance is allowed.  The weight allowances below are in addition to any unaccompanied or accompanied baggage.  Furthermore, in the event the <%= abbr_tag('tdy') %> location becomes the permanent duty station, this would mean that the <%= abbr_tag('tdy') %> weight allowance would also be an additional allowance to any PCS weight entitlements.</p>
 
-      <p>Check out the table below. You’ll find out just how much you are allowed to ship to this location.</p>
+      <p>Check out the table below. You'll find out just how much you are allowed to ship to this location.</p>
 
       <table>
         <thead>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,6 +39,7 @@ en:
     gps: Global Positioning System
     hhg: Household Goods
     jtr: Joint Travel Regulations
+    nte: Not to Exceed
     nts: Non-Temporary Storage
     oconus: Outside the Continental United States
     pcs: Permanent Change of Station
@@ -47,6 +48,7 @@ en:
     pppo: Personal Property Processing Office
     ppso: Personal Property Shipping Office
     pov: Privately-Owned Vehicle
+    sit: Storage in Transit
     src: System Response Center
     tdy: Temporary Duty Yonder
   site:


### PR DESCRIPTION
## Checklist

I have…

- [x] run the application locally (`bin/rails server`) and verified that my changes behave as expected.
- [x] run static code analysis (`bin/rubocop`) and vulnerability scan (`bin/brakeman`) against my changes.
- [x] run the test suite (`bin/rake spec`) and verified that all tests pass.
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.

## Summary of Changes

This pull request…

- Adds the retirees / separatees what to expect page
- Changes the page title font size for narrow width screens

This branches off of the tdy branch, since it uses some elements introduced there.

Issue #66

## Testing

To verify the changes proposed in this pull request…

clone this repo
git checkout retirees
set up development dependencies according to CONTRIBUTING.md,
run bin/rails server, and
load up http://localhost:3000/moving-guide/retirees-separatees

## Screenshots
wide:
![screencapture-localhost-3000-moving-guide-retirees-separatees-1510166940376](https://user-images.githubusercontent.com/29409348/32568258-ac3d717a-c48b-11e7-9c41-d6018c4ecf35.png)

narrow:
![screencapture-localhost-3000-moving-guide-retirees-separatees-1510166962231](https://user-images.githubusercontent.com/29409348/32568263-b0fae5a8-c48b-11e7-8b5d-c830583b1c31.png)



