### PR TITLE
Change min width before sidenav moves to top of screen

### DIFF
--- a/app/assets/stylesheets/components/_sidenav.scss
+++ b/app/assets/stylesheets/components/_sidenav.scss
@@ -10,16 +10,9 @@ $sidenav-screen-width: 800px;
     width: 20%
   }
 
-  .sidenav-jump-to {
-    margin-bottom: 0.5rem;
-    @include media($sidenav-screen-width) {
-      display: none;
-    }
-  }
-
   .usa-sidenav-list {
     // undo sidenav styling
-    @media screen and (max-width: $sidenav-screen-width) {
+    @media screen and (max-width: $sidenav-screen-width - 1) {
       li {
         border-top: none;
       }
@@ -34,6 +27,13 @@ $sidenav-screen-width: 800px;
         }
       }
     }
+  }
+}
+
+.sidenav-jump-to {
+  margin-bottom: 0.5rem;
+  @include media($sidenav-screen-width) {
+    display: none;
   }
 }
 

--- a/app/assets/stylesheets/components/_sidenav.scss
+++ b/app/assets/stylesheets/components/_sidenav.scss
@@ -1,20 +1,25 @@
-.sidenav {
-  width: 90%;
+$sidenav-screen-width: 800px;
 
-  @include media($large-screen) {
+.sidenav {
+  float: left;
+  margin-right: 5%;
+  width: 100%;
+
+  @include media($sidenav-screen-width) {
     padding-top: 1.5rem;
+    width: 20%
   }
 
   .sidenav-jump-to {
     margin-bottom: 0.5rem;
-    @include media($large-screen) {
+    @include media($sidenav-screen-width) {
       display: none;
     }
   }
 
   .usa-sidenav-list {
     // undo sidenav styling
-    @media screen and (max-width: $large-screen) {
+    @media screen and (max-width: $sidenav-screen-width) {
       li {
         border-top: none;
       }
@@ -29,5 +34,14 @@
         }
       }
     }
+  }
+}
+
+.sidenav-body {
+  float: left;
+  width: 100%;
+
+  @include media($sidenav-screen-width) {
+    width: 75%;
   }
 }

--- a/app/assets/stylesheets/components/_what_to_expect.scss
+++ b/app/assets/stylesheets/components/_what_to_expect.scss
@@ -1,10 +1,11 @@
 .what-to-expect-body {
   .what-to-expect-intro {
     background-color: $color-gray-cool-light;
-    @include margin(2rem 0);
+    @include margin(2rem 0-$site-margins-mobile);
     @include padding($site-margins-mobile);
 
     @include media($medium-screen) {
+      @include margin(2rem 0);
       @include padding($site-margins);
     }
   }

--- a/app/views/pages/moving-guide/retirees-separatees.html.erb
+++ b/app/views/pages/moving-guide/retirees-separatees.html.erb
@@ -5,29 +5,27 @@
 <div class="usa-section main-section">
   <h1><%= @page_title %></h1>
 
-  <div class="usa-width-one-fourth">
-    <aside class="sidenav">
-      <div class="sidenav-jump-to">
-        Jump to:
-      </div>
-      <ul class="usa-sidenav-list">
-        <li><%= link_to 'Destination', '#destination' %></li>
-        <li><%= link_to 'Timing', '#timing' %></li>
-        <li><%= link_to 'Extensions', '#extensions' %></li>
-        <li><%= link_to 'Storage Options', '#storage' %></li>
-        <li><%= link_to 'Advance Payments', '#payments' %></li>
-        <li><%= link_to 'Short Distance Moves', '#short-distance' %></li>
-        <li><%= link_to 'Weight Entitlements', '#weight' %></li>
-        <li><%= link_to 'Personally Owned Vehicles (POV)', '#pov' %></li>
-        <li><%= link_to 'Pro Gear', '#pro-gear' %></li>
-        <li><%= link_to 'Shipping Methods', '#shipping' %></li>
-      </ul>
-    </aside>
-  </div>
+  <aside class="sidenav">
+    <div class="sidenav-jump-to">
+      Jump to:
+    </div>
+    <ul class="usa-sidenav-list">
+      <li><%= link_to 'Destination', '#destination' %></li>
+      <li><%= link_to 'Timing', '#timing' %></li>
+      <li><%= link_to 'Extensions', '#extensions' %></li>
+      <li><%= link_to 'Storage Options', '#storage' %></li>
+      <li><%= link_to 'Advance Payments', '#payments' %></li>
+      <li><%= link_to 'Short Distance Moves', '#short-distance' %></li>
+      <li><%= link_to 'Weight Entitlements', '#weight' %></li>
+      <li><%= link_to 'Personally Owned Vehicles (POV)', '#pov' %></li>
+      <li><%= link_to 'Pro Gear', '#pro-gear' %></li>
+      <li><%= link_to 'Shipping Methods', '#shipping' %></li>
+    </ul>
+  </aside>
 
-  <div class="usa-width-three-fourths what-to-expect-body">
+  <div class="sidenav-body what-to-expect-body">
     <div class="what-to-expect-intro">
-      At this point in your career, you are probably well versed in the <%= abbr_tag('pcs') %> process - making you wonder what the big differences are for this final move. It is  recommended that you reach out to your <%= link_to 'local personal property office', offices_path %> for help arranging your move.
+      At this point in your career, you are probably well versed in the <%= abbr_tag('pcs') %> process - making you wonder what the big differences are for this final move. It is recommended that you reach out to your <%= link_to 'local personal property office', offices_path %> for help arranging your move.
     </div>
 
     <h3>What is different about a retiree or separatee move?</h3>

--- a/app/views/pages/moving-guide/tdy.html.erb
+++ b/app/views/pages/moving-guide/tdy.html.erb
@@ -5,20 +5,18 @@
 <div class="usa-section main-section">
   <h1>What to Expect with a <%= abbr_tag('tdy') %> Move</h1>
 
-  <div class="usa-width-one-fourth">
-    <aside class="sidenav">
-      <div class="sidenav-jump-to">
-        Jump to:
-      </div>
-      <ul class="usa-sidenav-list">
-        <li><%= link_to raw("Shipping #{abbr_tag('tdy')} Household Goods"), '#shipping' %></li>
-        <li><%= link_to raw("Weight Allowances for #{abbr_tag('tdy')} Shipments"), '#weight_allowances' %></li>
-        <li><%= link_to raw("#{abbr_tag('tdy')} Shipments"), '#shipments' %></li>
-      </ul>
-    </aside>
-  </div>
+  <aside class="sidenav">
+    <div class="sidenav-jump-to">
+      Jump to:
+    </div>
+    <ul class="usa-sidenav-list">
+      <li><%= link_to raw("Shipping #{abbr_tag('tdy')} Household Goods"), '#shipping' %></li>
+      <li><%= link_to raw("Weight Allowances for #{abbr_tag('tdy')} Shipments"), '#weight_allowances' %></li>
+      <li><%= link_to raw("#{abbr_tag('tdy')} Shipments"), '#shipments' %></li>
+    </ul>
+  </aside>
 
-  <div class="usa-width-three-fourths">
+  <div class="sidenav-body">
     <div id="shipping">
       <h4>Shipping <%= abbr_tag('tdy') %> Household Goods</h4>
       <p>If you find yourself heading out on Temporary Duty for an extended period of time (31 or more days), your Approving Official may authorize you to ship a small amount of household goods, to include some of your professional gear and medical equipment. Your <%= abbr_tag('tdy') %> shipment should be scheduled on the Defense Personal Property System (DPS) and as with any PCS visit your local Personal Property Office if you have any questions.</p>


### PR DESCRIPTION
I have…

- [x] run the application locally (`bin/rails server`) and verified that my changes behave as expected.
- [x] run static code analysis (`bin/rubocop`) and vulnerability scan (`bin/brakeman`) against my changes.
- [x] run the test suite (`bin/rake spec`) and verified that all tests pass.
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.

## Summary of Changes

This pull request...
1. Makes the minimum screen size 800px before the sidenav moves to the top of the screen.
2. Makes the blue intro box full width with no margin for medium screen. I think this is fine to do it for medium width instead of 800px, since I didn't want to hardcode 800px in 2 places.

## Testing

To verify the changes proposed in this pull request…

clone this repo
git checkout conus
set up development dependencies according to CONTRIBUTING.md,
run bin/rails server, and
load up http://localhost:3000/moving-guide/tdy and /retirees-separatees

## Screenshots

Min screen size with side nav (800px):
<img width="800" alt="screen shot 2017-11-09 at 3 21 12 pm" src="https://user-images.githubusercontent.com/29409348/32627830-d349a9b0-c561-11e7-9649-9fac21fe062a.png">


Max screen size with side nav on top (799px):
<img width="798" alt="screen shot 2017-11-09 at 3 21 24 pm" src="https://user-images.githubusercontent.com/29409348/32627835-d680d8ec-c561-11e7-9430-ba6e4baccd48.png">

Max screen size when blue box expands to full width:
<img width="592" alt="screen shot 2017-11-09 at 3 33 59 pm" src="https://user-images.githubusercontent.com/29409348/32628380-a6079fa0-c563-11e7-96ed-cf83c33bee67.png">

