### PR TITLE
Locator Map v3

### DIFF
--- a/app/assets/javascripts/components/coordinates-search-form.js
+++ b/app/assets/javascripts/components/coordinates-search-form.js
@@ -6,7 +6,8 @@
 
   var CoordinatesSearchForm = function(options) {
     this.$container = options.$container;
-    this.$input = options.$input;
+    this.$latitudeInput = options.$latitudeInput;
+    this.$longitudeInput = options.$longitudeInput;
     this.$button = options.$button;
     this.$errorContainer = options.$errorContainer;
     this.$noticeContainer = options.$noticeContainer;
@@ -38,7 +39,9 @@
         var coords = position.coords;
 
         if (coords) {
-          this.$input.val([coords.latitude, coords.longitude].join(','));
+          this.$latitudeInput.val(coords.latitude);
+          this.$longitudeInput.val(coords.longitude);
+
           this.$container.trigger('submit');
         }
       }
@@ -56,7 +59,8 @@
   if ($container.length) {
     new CoordinatesSearchForm({
       $container: $container,
-      $input: $('#coordinates'),
+      $latitudeInput: $('#latitude'),
+      $longitudeInput: $('#longitude'),
       $button: $container.find('button'),
       $errorContainer: $('#error-container'),
       $noticeContainer: $('#geolocation-notice')

--- a/app/assets/javascripts/components/coordinates-search-form.js
+++ b/app/assets/javascripts/components/coordinates-search-form.js
@@ -39,10 +39,9 @@
         var coords = position.coords;
 
         if (coords) {
-          this.$latitudeInput.val(coords.latitude);
-          this.$longitudeInput.val(coords.longitude);
+          this.$button.removeAttr('disabled');
 
-          this.$container.trigger('submit');
+          location.href = this.$container.attr('action') + '/' + coords.latitude + ',' + coords.longitude;
         }
       }
     },

--- a/app/assets/javascripts/components/coordinates-search.js
+++ b/app/assets/javascripts/components/coordinates-search.js
@@ -4,20 +4,16 @@
   var disabledButtonClassName = 'usa-button-disabled',
       errorMessageHTML = '<div class="usa-alert usa-alert-error" role="alert"><div class="usa-alert-body"><p class="usa-alert-text">There was a problem determining your location. Please reload the page and try again.</p></div></div>';
 
-  var CoordinatesSearchForm = function(options) {
+  var CoordinatesSearch = function(options) {
     this.$container = options.$container;
-    this.$latitudeInput = options.$latitudeInput;
-    this.$longitudeInput = options.$longitudeInput;
     this.$button = options.$button;
     this.$errorContainer = options.$errorContainer;
     this.$noticeContainer = options.$noticeContainer;
 
-    if (navigator.geolocation) {
-      this.setup();
-    }
+    this.setup();
   };
 
-  CoordinatesSearchForm.prototype = {
+  CoordinatesSearch.prototype = {
     events: {
       click: function(event) {
         event.preventDefault();
@@ -41,7 +37,7 @@
         if (coords) {
           this.$button.removeAttr('disabled');
 
-          location.href = this.$container.attr('action') + '/' + coords.latitude + ',' + coords.longitude;
+          location.href = this.$button.data('action') + '/' + coords.latitude + ',' + coords.longitude;
         }
       }
     },
@@ -53,13 +49,11 @@
     }
   };
 
-  var $container = $('#coordinates-search-form');
+  var $container = $('#coordinates-search');
 
-  if ($container.length) {
-    new CoordinatesSearchForm({
+  if (navigator.geolocation && $container.length) {
+    new CoordinatesSearch({
       $container: $container,
-      $latitudeInput: $('#latitude'),
-      $longitudeInput: $('#longitude'),
       $button: $container.find('button'),
       $errorContainer: $('#error-container'),
       $noticeContainer: $('#geolocation-notice')

--- a/app/assets/stylesheets/components/_forms.scss
+++ b/app/assets/stylesheets/components/_forms.scss
@@ -32,7 +32,7 @@
     @include media($small-screen) {
       float: left;
       margin: 0;
-      width: 15rem;
+      width: 26rem;
     }
   }
 

--- a/app/assets/stylesheets/components/_forms.scss
+++ b/app/assets/stylesheets/components/_forms.scss
@@ -44,10 +44,11 @@
   }
 }
 
-.coordinates-search-form {
+.coordinates-search {
   margin-top: $site-margins-mobile;
 
   @include media(42rem) {
+    float: left;
     margin: 0 0 0 $site-margins-mobile;
   }
 }

--- a/app/assets/stylesheets/components/_layout.scss
+++ b/app/assets/stylesheets/components/_layout.scss
@@ -86,6 +86,7 @@
   position: -webkit-sticky;
   position: sticky;
   top: 1rem;
+  z-index: 1000;
 
   @include media($nav-width) {
     margin-top: -3.75rem;

--- a/app/controllers/offices_controller.rb
+++ b/app/controllers/offices_controller.rb
@@ -1,10 +1,10 @@
 class OfficesController < ApplicationController
   def index
     return unless search
-    return @error_message = search.error_message unless search.valid?
-    return redirect_to offices_path(search.result) if request.post?
+    return error_message unless search.valid?
+    return transportation_offices unless request.post?
 
-    @transportation_offices = TransportationOffice.by_distance_with_shipping_office(search.result).paginate(page: params[:page])
+    redirect_to offices_path(search.result)
   end
 
   private
@@ -13,12 +13,20 @@ class OfficesController < ApplicationController
     CoordinatesSearch.new(params) if params[:latitude].present? && params[:longitude].present?
   end
 
+  def error_message
+    @error_message ||= search.error_message
+  end
+
   def installation_search
     InstallationSearch.new(params) if params[:query].present?
   end
 
   def search
     @search ||= coordinates_search || zip_code_search || installation_search || nil
+  end
+
+  def transportation_offices
+    @transportation_offices ||= TransportationOffice.by_distance_with_shipping_office(search.result).paginate(page: params[:page])
   end
 
   def zip_code_search

--- a/app/controllers/offices_controller.rb
+++ b/app/controllers/offices_controller.rb
@@ -2,6 +2,7 @@ class OfficesController < ApplicationController
   def index
     return unless search
     return @error_message = search.error_message unless search.valid?
+    return redirect_to offices_path(search.result) if request.post?
 
     @transportation_offices = TransportationOffice.by_distance_with_shipping_office(search.result).paginate(page: params[:page])
   end

--- a/app/controllers/offices_controller.rb
+++ b/app/controllers/offices_controller.rb
@@ -13,7 +13,7 @@ class OfficesController < ApplicationController
   end
 
   def coordinates_search
-    CoordinatesSearch.new(params) if params[:coordinates].present?
+    CoordinatesSearch.new(params) if params[:latitude].present? && params[:longitude].present?
   end
 
   def zip_code_search

--- a/app/controllers/offices_controller.rb
+++ b/app/controllers/offices_controller.rb
@@ -9,15 +9,19 @@ class OfficesController < ApplicationController
 
   private
 
-  def search
-    @search ||= coordinates_search || zip_code_search || nil
-  end
-
   def coordinates_search
     CoordinatesSearch.new(params) if params[:latitude].present? && params[:longitude].present?
   end
 
+  def installation_search
+    InstallationSearch.new(params) if params[:query].present?
+  end
+
+  def search
+    @search ||= coordinates_search || zip_code_search || installation_search || nil
+  end
+
   def zip_code_search
-    ZipCodeSearch.new(params) if params[:postal_code].present?
+    ZipCodeSearch.new(params) if params[:query].present? && /^\d{5}$/.match?(params[:query])
   end
 end

--- a/app/controllers/offices_controller.rb
+++ b/app/controllers/offices_controller.rb
@@ -1,9 +1,15 @@
 class OfficesController < ApplicationController
   def index
+    # return on direct requests to the page
     return unless search
+
+    # return error message on invalid search
     return error_message unless search.valid?
+
+    # return search results on valid search (GET)
     return transportation_offices unless request.post?
 
+    # redirect on valid search (POST)
     redirect_to offices_path(search.result)
   end
 

--- a/app/models/coordinates_search.rb
+++ b/app/models/coordinates_search.rb
@@ -1,4 +1,7 @@
 class CoordinatesSearch
+  LATITUDE_REGEXP = /^[-+]?([1-8]?\d(\.\d+)?|90(\.0+)?)$/
+  LONGITUDE_REGEXP = /^[-+]?(180(\.0+)?|((1[0-7]\d)|([1-9]?\d))(\.\d+)?)$/
+
   def initialize(params)
     @params = params
   end
@@ -8,25 +11,23 @@ class CoordinatesSearch
   end
 
   def query
-    search_params[:coordinates]
+    search_params.values.join(', ')
   end
 
   def result
-    coordinates_parts = search_params[:coordinates].split(',')
-
     {
-      latitude: coordinates_parts.first,
-      longitude: coordinates_parts.last
+      latitude: search_params[:latitude],
+      longitude: search_params[:longitude]
     }
   end
 
   def valid?
-    search_params.permitted? && /^[-+]?([1-8]?\d(\.\d+)?|90(\.0+)?),[-+]?(180(\.0+)?|((1[0-7]\d)|([1-9]?\d))(\.\d+)?)$/.match?(search_params[:coordinates])
+    search_params.permitted? && LATITUDE_REGEXP.match?(search_params[:latitude]) && LONGITUDE_REGEXP.match?(search_params[:longitude])
   end
 
   private
 
   def search_params
-    @search_params ||= @params.permit(:coordinates)
+    @search_params ||= @params.permit(:latitude, :longitude)
   end
 end

--- a/app/models/installation_search.rb
+++ b/app/models/installation_search.rb
@@ -1,0 +1,34 @@
+class InstallationSearch
+  def initialize(params)
+    @params = params
+  end
+
+  def error_message
+    'There was a problem locating that installation. Mind trying your search again?'
+  end
+
+  def query
+    search_params[:query]
+  end
+
+  def result
+    {
+      latitude: installation.latitude,
+      longitude: installation.longitude
+    }
+  end
+
+  def valid?
+    search_params.permitted? && installation
+  end
+
+  private
+
+  def installation
+    @installation ||= Installation.find_by('name ILIKE ?', "%#{search_params[:query]}%")
+  end
+
+  def search_params
+    @search_params ||= @params.permit(:query)
+  end
+end

--- a/app/models/zip_code_search.rb
+++ b/app/models/zip_code_search.rb
@@ -8,7 +8,7 @@ class ZipCodeSearch
   end
 
   def query
-    search_params[:postal_code].rjust(5, '0')
+    search_params[:query].rjust(5, '0')
   end
 
   def result
@@ -19,16 +19,16 @@ class ZipCodeSearch
   end
 
   def valid?
-    search_params.permitted? && /^\d{5}$/.match?(search_params[:postal_code]) && zip_code_tabulation_area
+    search_params.permitted? && /^\d{5}$/.match?(search_params[:query]) && zip_code_tabulation_area
   end
 
   private
 
   def search_params
-    @search_params ||= @params.permit(:postal_code)
+    @search_params ||= @params.permit(:query)
   end
 
   def zip_code_tabulation_area
-    @zip_code_tabulation_area ||= ZipCodeTabulationArea.find_by(zip_code: search_params[:postal_code])
+    @zip_code_tabulation_area ||= ZipCodeTabulationArea.find_by(zip_code: search_params[:query])
   end
 end

--- a/app/models/zip_code_search.rb
+++ b/app/models/zip_code_search.rb
@@ -8,12 +8,10 @@ class ZipCodeSearch
   end
 
   def query
-    search_params[:postal_code]
+    search_params[:postal_code].rjust(5, '0')
   end
 
   def result
-    zip_code_tabulation_area = ZipCodeTabulationArea.find_by(zip_code: search_params[:postal_code])
-
     {
       latitude: zip_code_tabulation_area.latitude,
       longitude: zip_code_tabulation_area.longitude
@@ -21,12 +19,16 @@ class ZipCodeSearch
   end
 
   def valid?
-    search_params.permitted? && /^\d{5}$/.match?(search_params[:postal_code])
+    search_params.permitted? && /^\d{5}$/.match?(search_params[:postal_code]) && zip_code_tabulation_area
   end
 
   private
 
   def search_params
     @search_params ||= @params.permit(:postal_code)
+  end
+
+  def zip_code_tabulation_area
+    @zip_code_tabulation_area ||= ZipCodeTabulationArea.find_by(zip_code: search_params[:postal_code])
   end
 end

--- a/app/views/offices/index.html.erb
+++ b/app/views/offices/index.html.erb
@@ -22,15 +22,17 @@
   </div>
 
   <div class="search-forms-container">
-    <%= form_with url: offices_path, class: 'usa-form zip-code-search-form', id: 'search-code-zip-form', method: 'get', skip_enforcing_utf8: true do |form| %>
+    <%= form_with url: offices_path, class: 'usa-form zip-code-search-form', id: 'search-code-zip-form' do |form| %>
       <%= form.label :postal_code, 'Search by ZIP Code', class: 'usa-input-required usa-sr-only' %>
-      <%= form.number_field :postal_code, aria: { required: true }, id: 'postal_code', pattern: '^\d{5}$', placeholder: 'e.g. 20500', required: true, value: params[:postal_code] %>
+      <%= form.text_field :postal_code, aria: { required: true }, id: 'postal_code', pattern: '^\d{5}$', placeholder: 'e.g. 20500', required: true %>
 
       <button>Search by ZIP Code</button>
     <% end %>
 
-    <%= form_with url: offices_path, class: 'usa-form coordinates-search-form', html: { hidden: true }, id: 'coordinates-search-form', method: 'get', skip_enforcing_utf8: true do |form| %>
-      <%= form.hidden_field :coordinates, id: 'coordinates' %>
+    <%= form_with url: offices_path, class: 'usa-form coordinates-search-form', html: { hidden: true }, id: 'coordinates-search-form' do |form| %>
+      <%= form.hidden_field :latitude, id: 'latitude' %>
+      <%= form.hidden_field :longitude, id: 'longitude' %>
+
       <button>Search by Your Location</button>
     <% end %>
   </div>

--- a/app/views/offices/index.html.erb
+++ b/app/views/offices/index.html.erb
@@ -29,12 +29,9 @@
       <button>Search</button>
     <% end %>
 
-    <%= form_with url: offices_path, class: 'usa-form coordinates-search-form', html: { hidden: true }, id: 'coordinates-search-form' do |form| %>
-      <%= form.hidden_field :latitude, id: 'latitude' %>
-      <%= form.hidden_field :longitude, id: 'longitude' %>
-
-      <button>Search by Your Location</button>
-    <% end %>
+    <div class="coordinates-search" id="coordinates-search" hidden>
+      <button data-action="<%= offices_path %>" type="button">Search by Your Location</button>
+    </div>
   </div>
 
   <%- if @transportation_offices -%>

--- a/app/views/offices/index.html.erb
+++ b/app/views/offices/index.html.erb
@@ -23,10 +23,10 @@
 
   <div class="search-forms-container">
     <%= form_with url: offices_path, class: 'usa-form zip-code-search-form', id: 'search-code-zip-form' do |form| %>
-      <%= form.label :postal_code, 'Search by ZIP Code', class: 'usa-input-required usa-sr-only' %>
-      <%= form.text_field :postal_code, aria: { required: true }, id: 'postal_code', pattern: '^\d{5}$', placeholder: 'e.g. 20500', required: true %>
+      <%= form.label :query, 'Search by ZIP Code or Installation', class: 'usa-input-required usa-sr-only' %>
+      <%= form.text_field :query, aria: { required: true }, id: 'query', placeholder: 'e.g. 20500, Fort Belvoir', required: true %>
 
-      <button>Search by ZIP Code</button>
+      <button>Search</button>
     <% end %>
 
     <%= form_with url: offices_path, class: 'usa-form coordinates-search-form', html: { hidden: true }, id: 'coordinates-search-form' do |form| %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
   get '/customer-service', to: 'customer_service#index', as: 'customer_service'
   get '/faqs', to: 'faqs#index', as: 'faqs'
   get '/resources/locator-maps', to: 'offices#index', as: 'offices'
+  post '/resources/locator-maps', to: 'offices#index'
   get '/resources/weight-estimator', to: 'weight_estimator#index', as: 'weight_estimator'
   get '/service-specific-information', to: 'service_specific_information#index', as: 'service_specific_information'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,12 @@ Rails.application.routes.draw do
 
   get '/customer-service', to: 'customer_service#index', as: 'customer_service'
   get '/faqs', to: 'faqs#index', as: 'faqs'
-  get '/resources/locator-maps', to: 'offices#index', as: 'offices'
+
+  get '/resources/locator-maps(/:latitude,:longitude)', to: 'offices#index', as: 'offices', constraints: {
+    latitude: /[-+]?([1-8]?\d(\.\d+)?|90(\.0+)?)/,
+    longitude: /[-+]?(180(\.0+)?|((1[0-7]\d)|([1-9]?\d))(\.\d+)?)/
+  }
+
   post '/resources/locator-maps', to: 'offices#index'
   get '/resources/weight-estimator', to: 'weight_estimator#index', as: 'weight_estimator'
   get '/service-specific-information', to: 'service_specific_information#index', as: 'service_specific_information'

--- a/spec/factories/installations.rb
+++ b/spec/factories/installations.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :installation do
     sequence(:name) { |n| "Installation #{n}" }
     latitude 38.6921631

--- a/spec/factories/installations.rb
+++ b/spec/factories/installations.rb
@@ -1,0 +1,9 @@
+FactoryGirl.define do
+  factory :installation do
+    sequence(:name) { |n| "Installation #{n}" }
+    latitude 38.6921631
+    # rubocop:disable Lint/AmbiguousOperator
+    longitude -77.1374000999999
+    # rubocop:enable Lint/AmbiguousOperator
+  end
+end

--- a/spec/requests/offices_spec.rb
+++ b/spec/requests/offices_spec.rb
@@ -13,11 +13,13 @@ RSpec.describe OfficesController, type: :request do
         assert_template 'index'
       end
     end
+  end
 
+  describe 'POST #index' do
     context 'when performing a ZIP code search' do
       context 'when sending invalid or incomplete params' do
         it 'displays an error message' do
-          get '/resources/locator-maps', params: { postal_code: 'foo' }
+          post '/resources/locator-maps', params: { postal_code: 'foo' }
 
           assert_select '.usa-alert-error .usa-alert-text', text: 'There was a problem locating that ZIP Code. Mind trying your search again?'
         end
@@ -28,7 +30,7 @@ RSpec.describe OfficesController, type: :request do
         let!(:transportation_offices) { create_list(:transportation_office, 20) }
 
         before do
-          get '/resources/locator-maps', params: { postal_code: '20010' }
+          post '/resources/locator-maps', params: { postal_code: '20010' }
         end
 
         it 'displays a map' do
@@ -45,7 +47,7 @@ RSpec.describe OfficesController, type: :request do
     context 'when performing a coordinates search' do
       context 'when sending invalid or incomplete params' do
         it 'displays an error message' do
-          get '/resources/locator-maps', params: { coordinates: '-100,181' }
+          post '/resources/locator-maps', params: { latitude: '-100', longitude: '181' }
 
           assert_select '.usa-alert-error .usa-alert-text', text: 'There was a problem performing that search. Mind trying again?'
         end
@@ -55,7 +57,7 @@ RSpec.describe OfficesController, type: :request do
         let!(:transportation_offices) { create_list(:transportation_office, 20) }
 
         before do
-          get '/resources/locator-maps', params: { coordinates: '38.933366,-77.0303119999999' }
+          post '/resources/locator-maps', params: { latitude: '38.933366', longitude: '-77.0303119999999' }
         end
 
         it 'displays a map' do

--- a/spec/requests/offices_spec.rb
+++ b/spec/requests/offices_spec.rb
@@ -33,28 +33,8 @@ RSpec.describe OfficesController, type: :request do
   end
 
   describe 'POST #index' do
-    context 'when performing a ZIP code search' do
-      context 'when sending invalid or incomplete params' do
-        it 'displays an error message' do
-          post '/resources/locator-maps', params: { postal_code: 'foo' }
-
-          assert_select '.usa-alert-error .usa-alert-text', text: 'There was a problem locating that ZIP Code. Mind trying your search again?'
-        end
-      end
-
-      context 'when sending valid params' do
-        let!(:zip_code_tabulation_area) { create(:zip_code_tabulation_area) }
-
-        it 'redirects to a search results page' do
-          post '/resources/locator-maps', params: { postal_code: '20010' }
-
-          expect(response).to redirect_to('/resources/locator-maps/38.933366,-77.0303119999999')
-        end
-      end
-    end
-
     context 'when performing a coordinates search' do
-      context 'when sending invalid or incomplete params' do
+      context 'when sending invalid params' do
         it 'displays an error message' do
           post '/resources/locator-maps', params: { latitude: '-100', longitude: '181' }
 
@@ -65,6 +45,46 @@ RSpec.describe OfficesController, type: :request do
       context 'when sending valid params' do
         it 'redirects to a search results page' do
           post '/resources/locator-maps', params: { latitude: '38.933366', longitude: '-77.0303119999999' }
+
+          expect(response).to redirect_to('/resources/locator-maps/38.933366,-77.0303119999999')
+        end
+      end
+    end
+
+    context 'when performing an installation search' do
+      context 'when no search results found' do
+        it 'displays an error message' do
+          post '/resources/locator-maps', params: { query: 'foo' }
+
+          assert_select '.usa-alert-error .usa-alert-text', text: 'There was a problem locating that installation. Mind trying your search again?'
+        end
+      end
+
+      context 'when search results found' do
+        let!(:installation) { create(:installation) }
+
+        it 'redirects to a search results page' do
+          post '/resources/locator-maps', params: { query: 'installation' }
+
+          expect(response).to redirect_to('/resources/locator-maps/38.6921631,-77.1374000999999')
+        end
+      end
+    end
+
+    context 'when performing a ZIP code search' do
+      context 'when no search results found' do
+        it 'displays an error message' do
+          post '/resources/locator-maps', params: { query: '00000' }
+
+          assert_select '.usa-alert-error .usa-alert-text', text: 'There was a problem locating that ZIP Code. Mind trying your search again?'
+        end
+      end
+
+      context 'when search results found' do
+        let!(:zip_code_tabulation_area) { create(:zip_code_tabulation_area) }
+
+        it 'redirects to a search results page' do
+          post '/resources/locator-maps', params: { query: '20010' }
 
           expect(response).to redirect_to('/resources/locator-maps/38.933366,-77.0303119999999')
         end

--- a/spec/requests/offices_spec.rb
+++ b/spec/requests/offices_spec.rb
@@ -13,6 +13,23 @@ RSpec.describe OfficesController, type: :request do
         assert_template 'index'
       end
     end
+
+    context 'when navigating to the page with coordinates' do
+      let!(:transportation_offices) { create_list(:transportation_office, 20) }
+
+      before do
+        get '/resources/locator-maps/38.933366,-77.0303119999999'
+      end
+
+      it 'displays a map' do
+        assert_select '#locator-map'
+      end
+
+      it 'displays a paginated list of transportation offices' do
+        assert_select '.transportation-office', count: 10
+        assert_select '.pagination'
+      end
+    end
   end
 
   describe 'POST #index' do
@@ -27,19 +44,11 @@ RSpec.describe OfficesController, type: :request do
 
       context 'when sending valid params' do
         let!(:zip_code_tabulation_area) { create(:zip_code_tabulation_area) }
-        let!(:transportation_offices) { create_list(:transportation_office, 20) }
 
-        before do
+        it 'redirects to a search results page' do
           post '/resources/locator-maps', params: { postal_code: '20010' }
-        end
 
-        it 'displays a map' do
-          assert_select '#locator-map'
-        end
-
-        it 'displays a paginated list of transportation offices' do
-          assert_select '.transportation-office', count: 10
-          assert_select '.pagination'
+          expect(response).to redirect_to('/resources/locator-maps/38.933366,-77.0303119999999')
         end
       end
     end
@@ -54,19 +63,10 @@ RSpec.describe OfficesController, type: :request do
       end
 
       context 'when sending valid params' do
-        let!(:transportation_offices) { create_list(:transportation_office, 20) }
-
-        before do
+        it 'redirects to a search results page' do
           post '/resources/locator-maps', params: { latitude: '38.933366', longitude: '-77.0303119999999' }
-        end
 
-        it 'displays a map' do
-          assert_select '#locator-map'
-        end
-
-        it 'displays a paginated list of transportation offices' do
-          assert_select '.transportation-office', count: 10
-          assert_select '.pagination'
+          expect(response).to redirect_to('/resources/locator-maps/38.933366,-77.0303119999999')
         end
       end
     end


### PR DESCRIPTION
## Checklist

I have…

- [x] run the application locally (`bin/rails server`) and verified that my changes behave as expected.
- [x] run static code analysis (`bin/rubocop`) and vulnerability scan (`bin/brakeman`) against my changes.
- [x] run the test suite (`bin/rake spec`) and verified that all tests pass.
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.

## Summary of Changes

This pull request refactors the "PPPO and Weight Scales Locations" page map and search functionality. New and updated features include:

- Users can search by ZIP code or plain text (e.g. "Fort Belvoir"). This first pass at plain text search is very rudimentary and my intention is to research PostgreSQL fuzzy searching and implement enhancements in the near future.
- Search results page URLs are much cleaner and consistent irrespective of "kind" of search (ZIP code, plain text, and geolocation). Under the covers, the controller action handles the complication of determining the "kind" of search and ultimately renders or redirects a page at a URL like `resources/locator-maps/38.933366,-77.030312`. This behavior is inspired by Google Maps' URL structure.

## Testing

To verify the changes proposed in this pull request…

1. clone this repo,
1. `git checkout locator-maps-v3`,
1. set up development dependencies according to `CONTRIBUTING.md`,
1. run `bin/rails rake`,
1. run `bin/rails brakeman`,
1. run `bin/rails rubocop`,
1. run `bin/rails server`,
1. load up http://localhost:3000/resources/locator-maps in your Web browser of choice and try out some searches.