### PR TITLE
Fix footer logo stretch

### DIFF
--- a/app/assets/stylesheets/components/_footer.scss
+++ b/app/assets/stylesheets/components/_footer.scss
@@ -47,3 +47,7 @@
   font-family: $font-sans;
   font-size: $h4-font-size;
 }
+
+.usa-footer-logo-img {
+  height: 100%;
+}


### PR DESCRIPTION
## Checklist

I have…

- [x] run the application locally (`bin/rails server`) and verified that my changes behave as expected.
- [x] run static code analysis (`bin/rubocop`) and vulnerability scan (`bin/brakeman`) against my changes.
- [x] run the test suite (`bin/rake spec`) and verified that all tests pass.
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.

## Summary of Changes

This pull request fixes the stretched footer logo
Issue #149

## Testing

To verify the changes proposed in this pull request…
clone this repo
git checkout footer_ie10
set up development dependencies according to CONTRIBUTING.md,
run bin/rails server, and
load up http://localhost:3000/

## Screenshots

Before:
![screen shot 2017-11-27 at 5 29 36 pm](https://user-images.githubusercontent.com/29409348/33292820-90462478-d398-11e7-8adc-a198293ac91d.png)

After:
![screen shot 2017-11-27 at 5 28 12 pm](https://user-images.githubusercontent.com/29409348/33292804-83664684-d398-11e7-87f2-82ea447f93b6.png)
