### PR TITLE
Set width for footer logo (fix chrome + safari)

### DIFF
--- a/app/assets/stylesheets/components/_footer.scss
+++ b/app/assets/stylesheets/components/_footer.scss
@@ -50,4 +50,5 @@
 
 .usa-footer-logo-img {
   height: 100%;
+  width: 14rem;
 }


### PR DESCRIPTION
## Checklist

I have…

- [x] run the application locally (`bin/rails server`) and verified that my changes behave as expected.
- [x] run static code analysis (`bin/rubocop`) and vulnerability scan (`bin/brakeman`) against my changes.
- [x] run the test suite (`bin/rake spec`) and verified that all tests pass.
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.

## Summary of Changes

This pull request fixes the footer logo for Chrome + Safari

## Testing

To verify the changes proposed in this pull request…

clone this repo,
git checkout footer_img,
set up development dependencies according to CONTRIBUTING.md,
run bin/rails server, and
load up http://localhost:3000 in Chrome, Safari, IE10, and Firefox

I also tested changing width to 20rem (larger than max-width) and tested in all the browsers, since the newer version of the web design standards reduces the max-width. If we upgrade to that version, things will not break.


