### PR TITLE
Add Archive banner

### DIFF
--- a/app/assets/stylesheets/components/_archive-banner.scss
+++ b/app/assets/stylesheets/components/_archive-banner.scss
@@ -1,0 +1,8 @@
+.archive-banner {
+  @include padding($site-margins-mobile null);
+  background-color: $color-gray-cool-light;
+
+  a {
+    font-weight: bold;
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -58,6 +58,12 @@
       </div>
     </div>
 
+    <div class="archive-banner">
+      <div class="usa-grid">
+        <p><b>Welcome to the new <%= t('site.name') %>!</b> Can’t find what you’re looking for? Legacy content can be found at <%= link_to 'archive.move.mil', 'https://archive.move.mil' %>.</p>
+      </div>
+    </div>
+
     <div class="usa-navbar">
       <%= raw('<button class="usa-menu-btn">Menu</button>') %>
 
@@ -71,7 +77,9 @@
         <% end %>
       </div>
     </div>
+
     <div class="navbar-border"></div>
+
     <%- if current_page?(root_path) %>
       <section class="usa-hero">
         <%= render 'shared/nav' %>


### PR DESCRIPTION
## Checklist

I have…

- [x] run the application locally (`bin/rails server`) and verified that my changes behave as expected.
- [x] run static code analysis (`bin/rubocop`) and vulnerability scan (`bin/brakeman`) against my changes.
- [x] run the test suite (`bin/rake spec`) and verified that all tests pass.
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.

## Summary of Changes

This pull request adds a banner to the site notifying users of legacy content availability.

## Testing

To verify the changes proposed in this pull request…

1. clone this repo,
1. `git checkout add-archive-banner`,
1. set up development dependencies according to `CONTRIBUTING.md`,
1. run `bin/rails server`,
1. load up http://localhost:3000 and check out that banner!

## Screenshots

### Narrow viewport

<img width="447" alt="screen shot 2017-11-29 at 12 17 48 pm" src="https://user-images.githubusercontent.com/27780860/33388941-60621786-d4ff-11e7-9efd-31ccd1309068.png">

### Wide viewport

<img width="1202" alt="screen shot 2017-11-29 at 12 17 57 pm" src="https://user-images.githubusercontent.com/27780860/33388942-606dd9f4-d4ff-11e7-8ded-ee0fecdb8e81.png">
