### PR TITLE
Fix navigation discrepancies

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,7 +8,7 @@ module ApplicationHelper
   end
 
   def page_title
-    return "#{@page_title} — #{t('site.name')}" if @page_title
+    return "#{ActionView::Base.full_sanitizer.sanitize(@page_title)} — #{t('site.name')}" if @page_title
     "#{t('site.name')} — #{t('site.tagline', abbr: 'DOD')}"
   end
 end

--- a/app/views/entitlements/index.html.erb
+++ b/app/views/entitlements/index.html.erb
@@ -1,4 +1,4 @@
-<%- @page_title = 'Entitlements' -%>
+<%- @page_title = 'Entitlements/Guidelines' -%>
 
 <%= render partial: 'shared/contextual_header', locals: {page_title: @page_title, parent_pages: []} %>
 

--- a/app/views/errors/not_found.html.erb
+++ b/app/views/errors/not_found.html.erb
@@ -21,7 +21,7 @@
     <ul class="usa-unstyled-list">
       <li><%= link_to 'Moving in the Military', page_path('moving-guide') %></li>
       <li><%= link_to 'Entitlements/Guidelines', page_path('entitlements') %></li>
-      <li><%= link_to 'What to Expect?', page_path('moving-guide/conus') %></li>
+      <li><%= link_to 'What to Expect', page_path('moving-guide/conus') %></li>
       <li><%= link_to 'Moving Tips', page_path('moving-guide/tips') %></li>
       <li><%= link_to 'Nightmare Moves', page_path('moving-guide/nightmare-moves') %></li>
       <li><%= link_to raw("Overseas Moves (#{abbr_tag('oconus')})"), page_path('moving-guide/oconus') %></li>

--- a/app/views/offices/index.html.erb
+++ b/app/views/offices/index.html.erb
@@ -1,4 +1,4 @@
-<%- @page_title = 'Locator Maps' -%>
+<%- @page_title = 'Find Nearby Locations' -%>
 
 <%= render partial: 'shared/contextual_header', locals: {page_title: @page_title, parent_pages: [{name: 'Tools & Resources', path: page_path('resources')}]} %>
 

--- a/app/views/pages/moving-guide/civilians.html.erb
+++ b/app/views/pages/moving-guide/civilians.html.erb
@@ -1,9 +1,9 @@
-<%- @page_title = 'What to expect… Civilians' -%>
+<%- @page_title = "#{abbr_tag('dod')} Civilian Employees" -%>
 
 <%= render partial: 'shared/contextual_header', locals: {page_title: @page_title, parent_pages: []} %>
 
 <div class="usa-section main-section">
-  <h1><%= @page_title %></h1>
+  <h1><%= raw(@page_title) %></h1>
 
   <%# TODO Add page content %>
 

--- a/app/views/pages/moving-guide/conus.html.erb
+++ b/app/views/pages/moving-guide/conus.html.erb
@@ -1,4 +1,4 @@
-<%- @page_title = 'What to Expect?' -%>
+<%- @page_title = 'What to Expect' -%>
 
 <%= render partial: 'shared/contextual_header', locals: {page_title: @page_title, parent_pages: []} %>
 

--- a/app/views/pages/moving-guide/conus.html.erb
+++ b/app/views/pages/moving-guide/conus.html.erb
@@ -1,9 +1,9 @@
-<%- @page_title = 'What to Expect with a CONUS Move' -%>
+<%- @page_title = 'What to Expect?' -%>
 
 <%= render partial: 'shared/contextual_header', locals: {page_title: @page_title, parent_pages: []} %>
 
 <div class="usa-section main-section">
-  <h1>What to Expect with a <%= abbr_tag('conus') %> Move</h1>
+  <h1><%= @page_title %></h1>
 
   <aside class="sidenav">
     <div class="sidenav-jump-to">

--- a/app/views/pages/moving-guide/oconus.html.erb
+++ b/app/views/pages/moving-guide/oconus.html.erb
@@ -1,9 +1,9 @@
-<%- @page_title = 'What to Expect with an OCONUS Move' -%>
+<%- @page_title = "Overseas Moves (#{abbr_tag('oconus')})" -%>
 
 <%= render partial: 'shared/contextual_header', locals: {page_title: @page_title, parent_pages: []} %>
 
 <div class="usa-section main-section">
-  <h1>What to Expect with an <%= abbr_tag('oconus') %> (Overseas) Move</h1>
+  <h1><%= raw(@page_title) %></h1>
 
   <aside class="sidenav">
     <div class="sidenav-jump-to">

--- a/app/views/pages/moving-guide/retirees-separatees.html.erb
+++ b/app/views/pages/moving-guide/retirees-separatees.html.erb
@@ -1,4 +1,4 @@
-<%- @page_title = 'Retiree and Separatee Moves' -%>
+<%- @page_title = 'Retirees/Separatees' -%>
 
 <%= render partial: 'shared/contextual_header', locals: {page_title: @page_title, parent_pages: []} %>
 

--- a/app/views/pages/moving-guide/tdy.html.erb
+++ b/app/views/pages/moving-guide/tdy.html.erb
@@ -1,9 +1,9 @@
-<%- @page_title = 'What to Expect with a TDY Move' -%>
+<%- @page_title = "#{abbr_tag('tdy')} Moves" -%>
 
 <%= render partial: 'shared/contextual_header', locals: {page_title: @page_title, parent_pages: []} %>
 
 <div class="usa-section main-section">
-  <h1>What to Expect with a <%= abbr_tag('tdy') %> Move</h1>
+  <h1><%= raw(@page_title) %></h1>
 
   <aside class="sidenav">
     <div class="sidenav-jump-to">

--- a/app/views/pages/resources.html.erb
+++ b/app/views/pages/resources.html.erb
@@ -4,6 +4,7 @@
 
 <div class="usa-section main-section tools-resources">
   <h1><%= @page_title %></h1>
+
   <div class="usa-grid tools-links">
     <ul class="usa-unstyled-list usa-width-one-half tools-list">
       <li>

--- a/app/views/shared/_breadcrumbs.html.erb
+++ b/app/views/shared/_breadcrumbs.html.erb
@@ -2,8 +2,8 @@
   <%= link_to 'Home', root_path %> /
 
   <%- parent_pages.each do |parent_page| -%>
-    <%= link_to parent_page[:name], parent_page[:path] %> /
+    <%= link_to raw(parent_page[:name]), parent_page[:path] %> /
   <%- end -%>
 
-  <%= page_title %>
+  <%= raw(page_title) %>
 </div>

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -13,7 +13,7 @@
         <ul class="usa-nav-submenu" id="nav-moving-guide" aria-hidden="true">
           <li><%= link_to 'Moving with the Military Overview', page_path('moving-guide') %></li>
           <li><%= link_to 'Entitlements/Guidelines', page_path('entitlements') %></li>
-          <li><%= link_to 'What to Expect?', page_path('moving-guide/conus') %></li>
+          <li><%= link_to 'What to Expect', page_path('moving-guide/conus') %></li>
           <li><%= link_to 'Reimbursements', page_path('moving-guide/reimbursements') %></li>
           <li><%= link_to 'Moving Tips', page_path('moving-guide/tips') %></li>
           <li><%= link_to 'Nightmare Moves', page_path('moving-guide/nightmare-moves') %></li>


### PR DESCRIPTION
This PR fixes discrepancies between the site navigation and page titles that happened as a result of last-minute dashes toward launch.