### PR TITLE
Add nginx redirects

### DIFF
--- a/.ebextensions/nginx.config
+++ b/.ebextensions/nginx.config
@@ -228,6 +228,15 @@ files:
                          '$status"$request_time"$upstream_response_time"'
                          '$http_x_forwarded_for';
 
+      map_hash_bucket_size 128;
+      map $request_uri $redirect_uri {
+        /common/contact_help/dps_eta_and_move_mil_help.cfm  /customer-service;
+        /common/locator_maps/transportation_offices.cfm  /resources/locator-maps;
+        /common/what_is_dps/what_is_dps.cfm  https://archive.move.mil/common/what_is_dps/what_is_dps.cfm;
+        /dod/before_you_begin/dps_how_to_guides.cfm  /tutorials;
+        /dod/faq.cfm  /faqs;
+      }
+
       server {
         listen 80;
 
@@ -259,6 +268,10 @@ files:
         }
 
         location / {
+          if ($redirect_uri) {
+            return 301 $redirect_uri;
+          }
+
           try_files $uri @move-mil-rails;
         }
       }

--- a/.ebextensions/nginx.config
+++ b/.ebextensions/nginx.config
@@ -231,10 +231,31 @@ files:
       map_hash_bucket_size 128;
       map $request_uri $redirect_uri {
         /common/contact_help/dps_eta_and_move_mil_help.cfm  /customer-service;
+        /common/dps_login_registration_process/dps_registration.cfm  https://archive.move.mil/common/dps_login_registration_process/dps_registration.cfm;
+        /common/dps_login_registration_process/new_password.cfm  https://archive.move.mil/common/dps_login_registration_process/new_password.cfm;
+        /common/dps_login_registration_process/system_requirements.cfm  https://archive.move.mil/common/dps_login_registration_process/system_requirements.cfm;
+        /common/faq/faq.cfm  https://archive.move.mil/common/faq/faq.cfm;
+        /common/locator_maps/scale.cfm  /resources/locator-maps;
+        /common/locator_maps/trans_offices_pjf.cfm  /resources/locator-maps;
         /common/locator_maps/transportation_offices.cfm  /resources/locator-maps;
         /common/what_is_dps/what_is_dps.cfm  https://archive.move.mil/common/what_is_dps/what_is_dps.cfm;
+        /dod/accessing_dps/accessing_dps.cfm  https://archive.move.mil/dod/accessing_dps/accessing_dps.cfm;
         /dod/before_you_begin/dps_how_to_guides.cfm  /tutorials;
+        /dod/before_you_begin/prepare_for_your_move.cfm  /moving-guide;
+        /dod/before_you_begin/retirement_and_separation.cfm  /moving-guide/retirees-separatees;
+        /dod/before_you_begin/weight_allowance.cfm  /entitlements;
+        /dod/before_you_begin/privately_owned_vehicles.cfm  /entitlements#privately-owned-vehicle;
+        /dod/claims_css/css.cfm  https://archive.move.mil/dod/claims_css/css.cfm;
+        /dod/claims_css/dod_claims.cfm  /moving-guide/claims;
         /dod/faq.cfm  /faqs;
+        /dod/first_time_users/browser_compatibility.cfm  https://archive.move.mil/dod/first_time_users/browser_compatibility.cfm;
+        /dod/first_time_users/obtain_user_pass.cfm  https://archive.move.mil/dod/first_time_users/obtain_user_pass.cfm;
+        /dod/first_time_users/validate_branch_of_service.cfm  https://archive.move.mil/dod/first_time_users/validate_branch_of_service.cfm;
+        /dod/moving_resources/housing.cfm  https://archive.move.mil/dod/moving_resources/housing.cfm;
+        /dod/start_your_move/personally_procurred_move.cfm  https://archive.move.mil/dod/start_your_move/personally_procurred_move.cfm;
+        /dod/start_your_move/transportation_office.cfm  /resources/locator-maps;
+        /index.cfm  /;
+        /ppso/ppso_resources/dps_login_solution.cfm  https://archive.move.mil/ppso/ppso_resources/dps_login_solution.cfm;
       }
 
       server {


### PR DESCRIPTION
Add redirects in the nginx config from old move.mil pages to new pages if they exist, and otherwise to archive.move.mil. Tested by copying the file to the staging ec2 instance and testing that urls like http://move-mil-staging.us-east-1.elasticbeanstalk.com/dod/start_your_move/personally_procurred_move.cfm redirect

Issue #221