### PR TITLE
Rework nginx config files

### DIFF
--- a/.ebextensions/nginx.config
+++ b/.ebextensions/nginx.config
@@ -137,85 +137,173 @@ files:
 
       }
 
-  "/etc/nginx/conf.d/00_nginx.conf":
+  "/etc/nginx/nginx.conf":
     mode: "000644"
     owner: root
     group: root
     content: |
-      # Hide nginx version information.
-      # Default: on
-      server_tokens off;
+      # Configuration File - Nginx Server Configs
+      # http://nginx.org/en/docs/dirindex.html
 
-      # Update charset_types to match updated mime.types.
-      # text/html is always included by charset module.
-      # Default: text/html text/xml text/plain text/vnd.wap.wml application/javascript application/rss+xml
-      charset_types
-        text/css
-        text/plain
-        text/vnd.wap.wml
-        application/javascript
-        application/json
-        application/rss+xml
-        application/xml;
+      # Run as a unique, less privileged user for security reasons.
+      # Default: nobody nobody
+      user nginx;
 
-      # Enable gzip compression.
-      # Default: off
-      gzip on;
-
-      # Compression level (1-9).
-      # 5 is a perfect compromise between size and CPU usage, offering about
-      # 75% reduction for most ASCII files (almost identical to level 9).
+      # Sets the worker threads to the number of CPU cores available in the system for best performance.
+      # Should be > the number of CPU cores.
+      # Maximum number of connections = worker_processes * worker_connections
       # Default: 1
-      gzip_comp_level    5;
+      worker_processes auto;
 
-      # Don't compress anything that's already small and unlikely to shrink much
-      # if at all (the default is 20 bytes, which is bad as that usually leads to
-      # larger files after gzipping).
-      # Default: 20
-      gzip_min_length    256;
+      # Maximum number of open files per worker process.
+      # Should be > worker_connections.
+      # Default: no limit
+      worker_rlimit_nofile 8192;
 
-      # Compress data even for clients that are connecting to us via proxies,
-      # identified by the "Via" header (required for CloudFront).
-      # Default: off
-      gzip_proxied       any;
+      events {
+        # If you need more connections than this, you start optimizing your OS.
+        # That's probably the point at which you hire people who are smarter than you as this is *a lot* of requests.
+        # Should be < worker_rlimit_nofile.
+        # Default: 512
+        worker_connections 8000;
+      }
 
-      # Tell proxies to cache both the gzipped and regular version of a resource
-      # whenever the client's Accept-Encoding capabilities header varies;
-      # Avoids the issue where a non-gzip capable client (which is extremely rare
-      # today) would display gibberish if their proxy gave them the gzipped version.
-      # Default: off
-      gzip_vary          on;
+      # Log errors and warnings to this file
+      # This is only used when you don't override it on a server{} level
+      # Default: logs/error.log error
+      error_log  /var/log/nginx/error.log warn;
 
-      # Compress all output labeled with one of the following MIME-types.
-      # text/html is always compressed by gzip module.
-      # Default: text/html
-      gzip_types
-        application/atom+xml
-        application/javascript
-        application/json
-        application/ld+json
-        application/manifest+json
-        application/rss+xml
-        application/vnd.geo+json
-        application/vnd.ms-fontobject
-        application/x-font-ttf
-        application/x-web-app-manifest+json
-        application/xhtml+xml
-        application/xml
-        font/opentype
-        image/bmp
-        image/svg+xml
-        image/x-icon
-        text/cache-manifest
-        text/css
-        text/plain
-        text/vcard
-        text/vnd.rim.location.xloc
-        text/vtt
-        text/x-component
-        text/x-cross-domain-policy;
+      # The file storing the process ID of the main process
+      # Default: nginx.pid
+      pid        /var/run/nginx.pid;
 
-  "/etc/nginx/conf.d/01_move-mil.conf":
+      http {
+        # Hide nginx version information.
+        # Default: on
+        server_tokens off;
+
+        # Specify MIME types for files.
+        include       mime.types;
+
+        # Default: text/plain
+        default_type  application/octet-stream;
+
+        # Update charset_types to match updated mime.types.
+        # text/html is always included by charset module.
+        # Default: text/html text/xml text/plain text/vnd.wap.wml application/javascript application/rss+xml
+        charset_types
+          text/css
+          text/plain
+          text/vnd.wap.wml
+          application/javascript
+          application/json
+          application/rss+xml
+          application/xml;
+
+        # Include $http_x_forwarded_for within default format used in log files
+        log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                          '$status $body_bytes_sent "$http_referer" '
+                          '"$http_user_agent" "$http_x_forwarded_for"';
+
+        log_format  healthd '$msec"$uri"'
+                            '$status"$request_time"$upstream_response_time"'
+                            '$http_x_forwarded_for';
+
+        # Log access to this file
+        # This is only used when you don't override it on a server{} level
+        # Default: logs/access.log combined
+        access_log /var/log/nginx/access.log main;
+
+        # How long to allow each connection to stay idle.
+        # Longer values are better for each individual client, particularly for SSL,
+        # but means that worker connections are tied up longer.
+        # Default: 75s
+        keepalive_timeout 20s;
+
+        # Speed up file transfers by using sendfile() to copy directly
+        # between descriptors rather than using read()/write().
+        # For performance reasons, on FreeBSD systems w/ ZFS
+        # this option should be disabled as ZFS's ARC caches
+        # frequently used files in RAM by default.
+        # Default: off
+        sendfile        on;
+
+        # Don't send out partial frames; this increases throughput
+        # since TCP frames are filled up before being sent out.
+        # Default: off
+        tcp_nopush      on;
+
+        # Enable gzip compression.
+        # Default: off
+        gzip on;
+
+        # Compression level (1-9).
+        # 5 is a perfect compromise between size and CPU usage, offering about
+        # 75% reduction for most ASCII files (almost identical to level 9).
+        # Default: 1
+        gzip_comp_level    5;
+
+        # Don't compress anything that's already small and unlikely to shrink much
+        # if at all (the default is 20 bytes, which is bad as that usually leads to
+        # larger files after gzipping).
+        # Default: 20
+        gzip_min_length    256;
+
+        # Compress data even for clients that are connecting to us via proxies,
+        # identified by the "Via" header (required for CloudFront).
+        # Default: off
+        gzip_proxied       any;
+
+        # Tell proxies to cache both the gzipped and regular version of a resource
+        # whenever the client's Accept-Encoding capabilities header varies;
+        # Avoids the issue where a non-gzip capable client (which is extremely rare
+        # today) would display gibberish if their proxy gave them the gzipped version.
+        # Default: off
+        gzip_vary          on;
+
+        # Compress all output labeled with one of the following MIME-types.
+        # text/html is always compressed by gzip module.
+        # Default: text/html
+        gzip_types
+          application/atom+xml
+          application/javascript
+          application/json
+          application/ld+json
+          application/manifest+json
+          application/rss+xml
+          application/vnd.geo+json
+          application/vnd.ms-fontobject
+          application/x-font-ttf
+          application/x-web-app-manifest+json
+          application/xhtml+xml
+          application/xml
+          font/opentype
+          image/bmp
+          image/svg+xml
+          image/x-icon
+          text/cache-manifest
+          text/css
+          text/plain
+          text/vcard
+          text/vnd.rim.location.xloc
+          text/vtt
+          text/x-component
+          text/x-cross-domain-policy;
+
+        # This should be turned on if you are going to have pre-compressed copies (.gz) of
+        # static files available. If not it should be left off as it will cause extra I/O
+        # for the check. It is best if you enable this in a location{} block for
+        # a specific directory, or on an individual server{} level.
+        # gzip_static on;
+
+        types_hash_max_size 2048;
+
+        map_hash_bucket_size 128;
+
+        include /etc/nginx/conf.d/*.conf;
+      }
+
+  "/etc/nginx/conf.d/move-mil.conf":
     mode: "000644"
     owner: root
     group: root
@@ -224,12 +312,83 @@ files:
         server unix:///var/run/puma/my_app.sock;
       }
 
-      log_format healthd '$msec"$uri"'
-                         '$status"$request_time"$upstream_response_time"'
-                         '$http_x_forwarded_for';
+      server {
+        listen [::]:80 deferred;
+        listen 80 deferred;
 
-      map_hash_bucket_size 128;
+        server_name _ localhost;
 
+        if ($time_iso8601 ~ "^(\d{4})-(\d{2})-(\d{2})T(\d{2})") {
+          set $year $1;
+          set $month $2;
+          set $day $3;
+          set $hour $4;
+        }
+
+        access_log /var/log/nginx/access.log main;
+        access_log /var/log/nginx/healthd/application.log.$year-$month-$day-$hour healthd;
+
+        root /var/app/current/public;
+
+        charset utf-8;
+
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://dap.digitalgov.gov https://www.google-analytics.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://www.google-analytics.com *.tile.openstreetmap.org; frame-ancestors 'none';" always;
+        add_header X-Content-Type-Options nosniff always;
+        add_header X-Frame-Options SAMEORIGIN always;
+        add_header X-UA-Compatible "IE=Edge";
+        add_header X-XSS-Protection "1; mode=block" always;
+
+        if ($redirect_uri) {
+          return 301 $redirect_uri;
+        }
+
+        try_files $uri @move-mil-rails;
+
+        error_page 404 = @move-mil-rails;
+        error_page 422 = /422.html;
+        error_page 500 = /500.html;
+
+        location @move-mil-rails {
+          proxy_pass http://move-mil-rails;
+          proxy_set_header Host $host;
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
+        # Prevent clients from accessing hidden files (starting with a dot)
+        # Access to `/.well-known/` is allowed.
+        location ~* /\.(?!well-known\/) {
+          deny all;
+        }
+
+        # Prevent clients from accessing to backup/config/source files
+        location ~* (?:\.(?:bak|conf|dist|fla|in[ci]|log|psd|sh|sql|sw[op])|~)$ {
+          deny all;
+        }
+
+        # Expire rules for static content
+
+        location ~* \.(?:css|js)$ {
+          access_log off;
+          add_header Cache-Control "max-age=31536000";
+        }
+
+        location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|webp|mp4|ogg|ogv|webm|htc)$ {
+          access_log off;
+          add_header Cache-Control "max-age=2592000";
+        }
+
+        location ~* \.svgz$ {
+          access_log off;
+          add_header Cache-Control "max-age=2592000";
+          gzip off;
+        }
+      }
+
+  "/etc/nginx/conf.d/redirects.conf":
+    mode: "000644"
+    owner: root
+    group: root
+    content: |
       map $request_uri $redirect_uri {
         /common/contact_help/dps_eta_and_move_mil_help.cfm  /customer-service;
         /common/dps_login_registration_process/dps_registration.cfm  https://archive.move.mil/common/dps_login_registration_process/dps_registration.cfm;
@@ -259,140 +418,9 @@ files:
         /dod/travel_information/uso_locations.cfm  https://archive.move.mil/dod/travel_information/uso_locations.cfm;
         /home.htm  /;
         /index.cfm  /;
+        /index.htm  /;
+        /index.html  /;
         /ppso/ppso_resources/dps_login_solution.cfm  https://archive.move.mil/ppso/ppso_resources/dps_login_solution.cfm;
-      }
-
-      server {
-        listen 80;
-
-        server_name _ localhost;
-
-        if ($time_iso8601 ~ "^(\d{4})-(\d{2})-(\d{2})T(\d{2})") {
-          set $year $1;
-          set $month $2;
-          set $day $3;
-          set $hour $4;
-        }
-
-        access_log /var/log/nginx/access.log main;
-        access_log /var/log/nginx/healthd/application.log.$year-$month-$day-$hour healthd;
-
-        include /etc/nginx/extras/directive-only/extra-security.conf;
-        include /etc/nginx/extras/directive-only/x-ua-compatible.conf;
-        include /etc/nginx/extras/location/expires.conf;
-        include /etc/nginx/extras/location/protect-system-files.conf;
-
-        root /var/app/current/public;
-
-        charset utf-8;
-
-        location @move-mil-rails {
-          proxy_pass http://move-mil-rails;
-          proxy_set_header Host $host;
-          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        }
-
-        location / {
-          if ($redirect_uri) {
-            return 301 $redirect_uri;
-          }
-
-          try_files $uri @move-mil-rails;
-        }
-      }
-
-  "/etc/nginx/extras/directive-only/extra-security.conf":
-    mode: "000644"
-    owner: root
-    group: root
-    content: |
-      # The X-Frame-Options header indicates whether a browser should be allowed
-      # to render a page within a frame or iframe.
-      add_header X-Frame-Options SAMEORIGIN always;
-
-      # MIME type sniffing security protection
-      #	There are very few edge cases where you wouldn't want this enabled.
-      add_header X-Content-Type-Options nosniff always;
-
-      # The X-XSS-Protection header is used by Internet Explorer version 8+
-      # The header instructs IE to enable its inbuilt anti-cross-site scripting filter.
-      add_header X-XSS-Protection "1; mode=block" always;
-
-      # with Content Security Policy (CSP) enabled (and a browser that supports it (http://caniuse.com/#feat=contentsecuritypolicy),
-      # you can tell the browser that it can only download content from the domains you explicitly allow
-      # CSP can be quite difficult to configure, and cause real issues if you get it wrong
-      # There is website that helps you generate a policy here http://cspisawesome.com/
-      add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://dap.digitalgov.gov https://www.google-analytics.com; img-src 'self' data: https://www.google-analytics.com *.tile.openstreetmap.org; frame-ancestors 'none';" always;
-
-  "/etc/nginx/extras/directive-only/x-ua-compatible.conf":
-    mode: "000644"
-    owner: root
-    group: root
-    content: |
-      # Force the latest IE version
-      add_header X-UA-Compatible "IE=Edge";
-
-  "/etc/nginx/extras/location/expires.conf":
-    mode: "000644"
-    owner: root
-    group: root
-    content: |
-      # Expire rules for static content
-
-      # No default expire rule. This config mirrors that of apache as outlined in the
-      # html5-boilerplate .htaccess file. However, nginx applies rules by location,
-      # the apache rules are defined by type. A consequence of this difference is that
-      # if you use no file extension in the url and serve html, with apache you get an
-      # expire time of 0s, with nginx you'd get an expire header of one month in the
-      # future (if the default expire rule is 1 month). Therefore, do not use a
-      # default expire rule with nginx unless your site is completely static
-
-      # cache.appcache, your document html and data
-      location ~* \.(?:manifest|appcache|html?|xml|json)$ {
-        add_header Cache-Control "max-age=0";
-      }
-
-      # Feed
-      location ~* \.(?:rss|atom)$ {
-        add_header Cache-Control "max-age=3600";
-      }
-
-      # Media: images, icons, video, audio, HTC
-      location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|webp|mp4|ogg|ogv|webm|htc)$ {
-        access_log off;
-        add_header Cache-Control "max-age=2592000";
-      }
-
-      # Media: svgz files are already compressed.
-      location ~* \.svgz$ {
-        access_log off;
-        gzip off;
-        add_header Cache-Control "max-age=2592000";
-      }
-
-      # CSS and Javascript
-      location ~* \.(?:css|js)$ {
-        add_header Cache-Control "max-age=31536000";
-        access_log off;
-      }
-
-  "/etc/nginx/extras/location/protect-system-files.conf":
-    mode: "000644"
-    owner: root
-    group: root
-    content: |
-      # Prevent clients from accessing hidden files (starting with a dot)
-      # This is particularly important if you store .htpasswd files in the site hierarchy
-      # Access to `/.well-known/` is allowed.
-      # https://www.mnot.net/blog/2010/04/07/well-known
-      # https://tools.ietf.org/html/rfc5785
-      location ~* /\.(?!well-known\/) {
-        deny all;
-      }
-
-      # Prevent clients from accessing to backup/config/source files
-      location ~* (?:\.(?:bak|conf|dist|fla|in[ci]|log|psd|sh|sql|sw[op])|~)$ {
-        deny all;
       }
 
   "/opt/elasticbeanstalk/hooks/appdeploy/pre/99_remove_default_nginx_configuration.sh":

--- a/.ebextensions/nginx.config
+++ b/.ebextensions/nginx.config
@@ -332,10 +332,25 @@ files:
 
         charset utf-8;
 
+        # With Content Security Policy (CSP) enabled (and a browser that supports it (http://caniuse.com/#feat=contentsecuritypolicy),
+        # you can tell the browser that it can only download content from the domains you explicitly allow
+        # CSP can be quite difficult to configure, and cause real issues if you get it wrong
+        # There is website that helps you generate a policy here http://cspisawesome.com/
         add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://dap.digitalgov.gov https://www.google-analytics.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://www.google-analytics.com *.tile.openstreetmap.org; frame-ancestors 'none';" always;
+
+        # MIME type sniffing security protection
+        #	There are very few edge cases where you wouldn't want this enabled.
         add_header X-Content-Type-Options nosniff always;
+
+        # The X-Frame-Options header indicates whether a browser should be allowed
+        # to render a page within a frame or iframe.
         add_header X-Frame-Options SAMEORIGIN always;
+
+        # Force the latest IE version
         add_header X-UA-Compatible "IE=Edge";
+
+        # The X-XSS-Protection header is used by Internet Explorer version 8+
+        # The header instructs IE to enable its inbuilt anti-cross-site scripting filter.
         add_header X-XSS-Protection "1; mode=block" always;
 
         if ($redirect_uri) {


### PR DESCRIPTION
This PR updates the nginx configuration files, solving several redirection and 404-handling problems we noticed on our environments.

We'll need to test a deploy to staging to see if AWS/Elastic Beanstalk will properly overwrite the default `/etc/nginx/nginx.conf` file with our desired contents. It _should_ since we've observed `mime.types` being appropriately overwritten…

The default diff view is kinda heinous, so [the "split" view](https://github.com/deptofdefense/move.mil/pull/224/files?diff=split) might be easier on the eyes.

/cc @aileendds @hlieberman-gov 