### PR TITLE
Weight estimator CSS fixes

### DIFF
--- a/app/assets/stylesheets/components/_weight-estimator.scss
+++ b/app/assets/stylesheets/components/_weight-estimator.scss
@@ -1,5 +1,10 @@
 .hhg-category-list {
   margin-top: 2rem;
+
+  input {
+    height: 3.5rem;
+    padding: 0.5rem 1rem;
+  }
 }
 
 .hhg-category-header {
@@ -31,6 +36,8 @@
   }
 
   table {
+    width: 100%;
+
     td {
       border: none;
       padding: 1rem 1.5rem 0 1.5rem;
@@ -48,13 +55,11 @@
 .hhg-weight-input,
 .category-estimate-input {
   float: right;
-  height: 3.5rem;
   width: 5rem;
 }
 
 .category-estimate-input {
   float: right;
-  height: 3.5rem;
   width: 8rem;
 }
 
@@ -69,10 +74,6 @@
 
   .category-estimate-table {
     margin-top: 0;
-  }
-
-  .hhg-misc-input {
-    height: 3.5rem;
   }
 
   margin-top: 2rem;


### PR DESCRIPTION
## Checklist

I have…

- [x] run the application locally (`bin/rails server`) and verified that my changes behave as expected.
- [x] run static code analysis (`bin/rubocop`) and vulnerability scan (`bin/brakeman`) against my changes.
- [x] run the test suite (`bin/rake spec`) and verified that all tests pass.
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.

## Summary of Changes

This pull request makes some UI fixes that are necessary after removing the sidenav:
1. Make the tables full width. Now that they have more room, some dont take up full width and it looks weird that they're not all aligned.
2. Fix the input text alignment in IE

## Testing

To verify the changes proposed in this pull request…

clone this repo,
git checkout weight-est,
set up development dependencies according to CONTRIBUTING.md,
run bin/rails server, and
load up http://localhost:3000 in your Web browser of choice.

## Screenshots

Before (IE10):
![screen shot 2017-12-11 at 4 38 40 pm](https://user-images.githubusercontent.com/29409348/33855482-0487c288-de93-11e7-918a-44eb2d267faf.png)


After (IE10):
![screen shot 2017-12-11 at 4 39 27 pm](https://user-images.githubusercontent.com/29409348/33855490-0a5590dc-de93-11e7-80c2-2a52daece337.png)
