### PR TITLE
Add TLS verbiage to gov banner

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -52,7 +52,7 @@
             <%= image_tag 'uswds/icon-dot-gov.svg', alt: 'Dot gov', class: 'usa-banner-icon usa-media_block-img' %>
             <div class="usa-media_block-body">
               <p>
-                <b>The .gov means it’s official.</b>
+                <b>The .mil means it’s official.</b>
                 <br>
                 Federal government websites often end in .gov or .mil. Before sharing sensitive information, make sure you’re on a federal government site.
               </p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -48,13 +48,23 @@
         </div>
 
         <div class="usa-banner-content usa-grid usa-accordion-content" id="gov-banner">
-          <div class="usa-banner-guidance-gov">
+          <div class="usa-banner-guidance-gov usa-width-one-half">
             <%= image_tag 'uswds/icon-dot-gov.svg', alt: 'Dot gov', class: 'usa-banner-icon usa-media_block-img' %>
             <div class="usa-media_block-body">
               <p>
-                <strong>The .mil means it’s official.</strong>
+                <b>The .gov means it’s official.</b>
                 <br>
-                Federal government websites always use a .gov or .mil domain. Before sharing sensitive information online, make sure you’re on a .gov or .mil site by inspecting your browser’s address (or “location”) bar.
+                Federal government websites often end in .gov or .mil. Before sharing sensitive information, make sure you’re on a federal government site.
+              </p>
+            </div>
+          </div>
+          <div class="usa-banner-guidance-ssl usa-width-one-half">
+            <%= image_tag 'uswds/icon-https.svg', alt: 'SSL', class: 'usa-banner-icon usa-media_block-img' %>
+            <div class="usa-media_block-body">
+              <p>
+                <b>The site is secure.</b>
+                <br>
+                The <b>https://</b> ensures that you are connecting to the official website and that any information you provide is encrypted and transmitted securely.
               </p>
             </div>
           </div>


### PR DESCRIPTION
## Checklist

I have…

- [x] run the application locally (`bin/rails server`) and verified that my changes behave as expected.
- [x] run static code analysis (`bin/rubocop`) and vulnerability scan (`bin/brakeman`) against my changes.
- [x] run the test suite (`bin/rake spec`) and verified that all tests pass.
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.

## Summary of Changes

This pull request updates the content in the gov banner, adding the TLS note.

## Testing

To verify the changes proposed in this pull request…

1. clone this repo,
1. `git checkout update-gov-banner`,
1. set up development dependencies according to `CONTRIBUTING.md`,
1. run `bin/rails server`,
1. load up http://localhost:3000 and check out that banner!

## Screenshots

<img width="1252" alt="gov-banner" src="https://user-images.githubusercontent.com/27780860/33891694-c17a0b8a-df24-11e7-9c09-aff29afa5530.png">
