### PR TITLE
Fix entitlements table UI for IE10

### DIFF
--- a/app/assets/stylesheets/components/_special-items-navigation.scss
+++ b/app/assets/stylesheets/components/_special-items-navigation.scss
@@ -2,8 +2,11 @@
   @include clearfix;
   @include unstyled-list;
   align-items: baseline;
+  -ms-flex-align: baseline;
   display: flex;
+  display: -ms-flexbox;
   flex-wrap: wrap;
+  -ms-flex-wrap: wrap;
   margin-top: $site-margins-mobile;
 
   li {


### PR DESCRIPTION
Issue #242
Also tested in Chrome and Safari

Before:
<img width="1278" alt="screen shot 2017-12-19 at 4 50 46 pm" src="https://user-images.githubusercontent.com/29409348/34180467-ca70f70e-e4dc-11e7-97c1-df82968b53d8.png">


After:
<img width="1197" alt="screen shot 2017-12-19 at 4 47 56 pm" src="https://user-images.githubusercontent.com/29409348/34180448-b03a7a9a-e4dc-11e7-98eb-13983dc58ca1.png">
