### PR TITLE
Add AF video to service page

### DIFF
--- a/.ebextensions/nginx.config
+++ b/.ebextensions/nginx.config
@@ -336,7 +336,7 @@ files:
         # you can tell the browser that it can only download content from the domains you explicitly allow
         # CSP can be quite difficult to configure, and cause real issues if you get it wrong
         # There is website that helps you generate a policy here http://cspisawesome.com/
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://dap.digitalgov.gov https://www.google-analytics.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://www.google-analytics.com *.tile.openstreetmap.org; frame-ancestors 'none';" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://dap.digitalgov.gov https://www.google-analytics.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://www.google-analytics.com *.tile.openstreetmap.org; frame-ancestors 'none'; frame-src https://www.youtube.com;" always;
 
         # MIME type sniffing security protection
         #	There are very few edge cases where you wouldn't want this enabled.

--- a/app/assets/stylesheets/components/_service-specific-info.scss
+++ b/app/assets/stylesheets/components/_service-specific-info.scss
@@ -6,6 +6,20 @@
   .sidebar-accordion {
     margin: 0 0-$site-margins-mobile 2rem 0-$site-margins-mobile;
   }
+
+  .video_wrapper {
+    padding-top: 56.25%;
+    position: relative;
+
+    iframe {
+      height: 100%;
+      left: 0;
+      margin-top: 1.5rem;
+      position: absolute;
+      top: 0;
+      width: 100%;
+    }
+  }
 }
 
 .svc-spec-banner {

--- a/app/views/service_specific_information/_air-force.html.erb
+++ b/app/views/service_specific_information/_air-force.html.erb
@@ -16,6 +16,9 @@
 
 <div class="usa-grid-full">
   <div class="usa-width-two-thirds">
+    <div class="video_wrapper">
+      <iframe src="https://www.youtube.com/embed/EyfE8aIASb4" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen></iframe>
+    </div>
     <%= render partial: 'posts', object: @branch.service_specific_posts %>
   </div>
 

--- a/spec/requests/service_specific_information_spec.rb
+++ b/spec/requests/service_specific_information_spec.rb
@@ -16,10 +16,10 @@ RSpec.describe ServiceSpecificInformationController, type: :request do
     end
 
     context 'when service specific posts exist' do
-      let!(:branch) { create(:branch_of_service, name: 'Air Force') }
+      let!(:branch) { create(:branch_of_service, name: 'Navy') }
 
       it 'displays a list of service specific posts' do
-        get '/service-specific-information/air-force'
+        get '/service-specific-information/navy'
 
         assert_select '.post', 2
 
@@ -28,7 +28,7 @@ RSpec.describe ServiceSpecificInformationController, type: :request do
       end
 
       it 'displays customer service contact information' do
-        get '/service-specific-information/air-force'
+        get '/service-specific-information/navy'
 
         assert_select '.svc-spec-links:first-child' do
           assert_select 'header', text: branch.name + ' Customer Service'


### PR DESCRIPTION
## Checklist

I have…

- [x] run the application locally (`bin/rails server`) and verified that my changes behave as expected.
- [x] run static code analysis (`bin/rubocop`) and vulnerability scan (`bin/brakeman`) against my changes.
- [x] run the test suite (`bin/rake spec`) and verified that all tests pass.
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.

## Summary of Changes

This pull request adds the AF video. Also updates the nginx config to allow iframes from youtube. Hopefully this is all that's needed but we'll see in staging.

Issue #261

## Testing

To verify the changes proposed in this pull request
clone this repo,
git checkout video,
set up development dependencies according to CONTRIBUTING.md,
run bin/rails server,
load up http://localhost:3000/resources/service-specific-information/air-force, watch video

## Screenshots

<details><summary>Desktop</summary>

![screencapture-localhost-3000-service-specific-information-air-force-1513880256051](https://user-images.githubusercontent.com/29409348/34269192-6ce2c6be-e651-11e7-89bb-6eb173df431e.png)

</details>

<details><summary>Mobile</summary>

![screencapture-localhost-3000-service-specific-information-air-force-1513880274599](https://user-images.githubusercontent.com/29409348/34269197-70e8bc78-e651-11e7-8fea-1b8a3f5f9cdd.png)

</details>