### PR TITLE
Fix tutorial buttons overlapping with title

### DIFF
--- a/app/assets/stylesheets/components/_carousel.scss
+++ b/app/assets/stylesheets/components/_carousel.scss
@@ -1,5 +1,10 @@
 .carousel {
+  margin-top: 3rem;
   position: relative;
+
+  @include media($small-screen) {
+    margin-top: 0;
+  }
 
   figure,
   figcaption {

--- a/app/assets/stylesheets/components/_tutorial.scss
+++ b/app/assets/stylesheets/components/_tutorial.scss
@@ -19,12 +19,16 @@
 }
 
 .show-all {
-  bottom: 0;
+  bottom: -3rem;
   margin: 0;
   padding: 0;
   position: absolute;
   right: 0;
   width: auto;
+
+  @include media($small-screen) {
+    bottom: 0;
+  }
 
   img {
     display: block;


### PR DESCRIPTION
## Checklist

I have…

- [x] run the application locally (`bin/rails server`) and verified that my changes behave as expected.
- [x] run static code analysis (`bin/rubocop`) and vulnerability scan (`bin/brakeman`) against my changes.
- [x] run the test suite (`bin/rake spec`) and verified that all tests pass.
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.

## Summary of Changes

This pull request fixes the tutorial UI for narrow screen widths

Issue #271 

## Testing

To verify the changes proposed in this pull request…

clone this repo,
git checkout locator-maps-v4,
set up development dependencies according to CONTRIBUTING.md,
run bin/rails server,
load up http://localhost:3000/tutorials

## Screenshots

before:
![screen shot 2018-01-03 at 3 23 07 pm](https://user-images.githubusercontent.com/29409348/34538354-131b3820-f09a-11e7-907c-c771dadff5b1.png)

after:
![screen shot 2018-01-03 at 3 23 21 pm](https://user-images.githubusercontent.com/29409348/34538362-17e4026a-f09a-11e7-9248-c05f98ead9ad.png)

  