### PR TITLE
Redirect to /tutorials for bad tutorial IDs instead of 500

### DIFF
--- a/app/controllers/tutorials_controller.rb
+++ b/app/controllers/tutorials_controller.rb
@@ -1,14 +1,14 @@
 class TutorialsController < ApplicationController
   def show
-    @tutorials = Tutorial.includes(:tutorial_steps).all.to_a
-    if params[:id]
-      @tutorial = @tutorials.find { |tutorial| tutorial.slug == params[:id] }
-      return unless @tutorial.nil?
+    return @tutorial = tutorials.first unless params[:id]
 
-      # Redirect to /tutorials on invalid / outdated tutorial ID
-      redirect_to tutorial_path
-    else
-      @tutorial = @tutorials.first
-    end
+    @tutorial = tutorials.find { |tutorial| tutorial.slug == params[:id] }
+
+    # Redirect on invalid / outdated tutorial ID
+    redirect_to tutorial_path if @tutorial.nil?
+  end
+
+  def tutorials
+    @tutorials ||= Tutorial.includes(:tutorial_steps).all
   end
 end

--- a/app/controllers/tutorials_controller.rb
+++ b/app/controllers/tutorials_controller.rb
@@ -1,6 +1,14 @@
 class TutorialsController < ApplicationController
   def show
     @tutorials = Tutorial.includes(:tutorial_steps).all.to_a
-    @tutorial = params[:id] ? @tutorials.find { |tutorial| tutorial.slug == params[:id] } : @tutorials.first
+    if params[:id]
+      @tutorial = @tutorials.find { |tutorial| tutorial.slug == params[:id] }
+      return unless @tutorial == nil
+
+      # Redirect to /tutorials on invalid / outdated tutorial ID
+      redirect_to tutorial_path
+    else
+      @tutorial = @tutorials.first
+    end
   end
 end

--- a/app/controllers/tutorials_controller.rb
+++ b/app/controllers/tutorials_controller.rb
@@ -3,7 +3,7 @@ class TutorialsController < ApplicationController
     @tutorials = Tutorial.includes(:tutorial_steps).all.to_a
     if params[:id]
       @tutorial = @tutorials.find { |tutorial| tutorial.slug == params[:id] }
-      return unless @tutorial == nil
+      return unless @tutorial.nil?
 
       # Redirect to /tutorials on invalid / outdated tutorial ID
       redirect_to tutorial_path


### PR DESCRIPTION
## Checklist

I have…

- [x] run the application locally (`bin/rails server`) and verified that my changes behave as expected.
- [x] run static code analysis (`bin/rubocop`) and vulnerability scan (`bin/brakeman`) against my changes.
- [x] run the test suite (`bin/rake spec`) and verified that all tests pass.
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [ ] attached screenshots illustrating relevant behavior before and after my changes.

## Summary of Changes

Instead of showing a 500, if someone goes to www.move.mil/tutorials/some-tutorial-that-doesnt-exist, redirect to /tutorials.
Google currently indexes some of the old tutorials and if someone clicks those links they get a 500.
Issue #281 

## Testing

To verify the changes proposed in this pull request…
clone this repo,
git checkout tutorials,
set up development dependencies according to CONTRIBUTING.md,
run bin/rails server, and
load up http://localhost:3000/tutorials/bleh
