### PR TITLE
updated tutorial seed data text per issue #341

### DIFF
--- a/db/seeds/tutorials.yml
+++ b/db/seeds/tutorials.yml
@@ -141,11 +141,11 @@
         </ul>
     - image_path: tutorials/create-a-shipment-09.jpg
       content: >
-        Next, enter your Orders Number and Date.
+        Next, enter your Orders Number, Date and the Headquarters Issuing the Orders.
       pro_tip: >
         <strong>Pro-Tips:</strong>
         <ul>
-          <li>The location of your Orders Number on the orders, varies by branch. Typically, the Army and Navy list the number in the upper left of the document, while the Marines list a Standard Document Number (SDN) on the bottom right. For the Airforce, look in box 27 of your Orders form.</li>
+          <li>The location of your Orders Number on the orders, varies by branch. Typically, the Army and Navy list the number in the upper left of the document, while the Marines list a Standard Document Number (SDN) on the bottom right. For the Air Force, look in box 27 of your Orders form.</li>
           <li>Your Orders date is the date the orders were cut or issued.</li>
         </ul>
     - image_path: tutorials/create-a-shipment-10.jpg


### PR DESCRIPTION
This is a simple change, very similar to the substantive fix recently merged in PR #373

## Checklist

I have…

- [x] run the application locally (`bin/rails server`) and verified that my changes behave as expected.
- [x] run static code analysis (`bin/rubocop`) and vulnerability scan (`bin/brakeman`) against my changes.
- [x] run the test suite (`bin/rake spec`) and verified that all tests pass.
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.
- [x] read, understand, and agree to the terms described in [CONTRIBUTING.md](https://github.com/deptofdefense/move.mil/blob/master/CONTRIBUTING.md).
- [x] added my name, email address, and copyright date to [CONTRIBUTORS.md](https://github.com/deptofdefense/move.mil/blob/master/CONTRIBUTORS.md).

## Summary of Changes

This pull request…

- Updates the text in two places on Slide #9 of the "Create a Shipment" tutorial.
- See [Issue #341 ](https://github.com/deptofdefense/move.mil/issues/341) for detail.
- Note: attribution already covered by @rich-allen-gov in PR #373

## Testing

To verify the changes proposed in this pull request…

1. Run `bundle exec rake db:reset` to verify that all data was dropped, and reseeded correctly.
1. Ensure content updates appear as expected. 
1. Capture changes with screenshot (below)

## Screenshots

BEFORE:
![issue 341 - create shipment slide 9 - before](https://user-images.githubusercontent.com/29130580/37386109-59daea0c-272d-11e8-805b-5cafe96872cc.png)

AFTER:
![issue 341 - create shipment slide 9 - after local](https://user-images.githubusercontent.com/29130580/37386050-13d98aea-272d-11e8-854c-34ab6584c51c.png)
