### PR TITLE
Singular, not plural, ranks in entitlement data

### DIFF
--- a/db/seeds/entitlements.yml
+++ b/db/seeds/entitlements.yml
@@ -1,8 +1,8 @@
-- rank: Service Academy Cadets/Midshipmen
+- rank: Service Academy Cadet/Midshipman
   total_weight_self: 350
   total_weight_self_plus_dependents: 350
 
-- rank: Aviation Cadets
+- rank: Aviation Cadet
   total_weight_self: 7000
   total_weight_self_plus_dependents: 8000
   pro_gear_weight: 2000
@@ -62,7 +62,7 @@
   pro_gear_weight: 2000
   pro_gear_weight_spouse: 500
 
-- rank: O-1/W-1/Service Academy Graduates
+- rank: O-1/W-1/Service Academy Graduate
   total_weight_self: 10000
   total_weight_self_plus_dependents: 12000
   pro_gear_weight: 2000


### PR DESCRIPTION
## Checklist

I have…

- [x] run the application locally (`bin/rails server`) and verified that my changes behave as expected.
- [x] run static code analysis (`bin/rubocop`) and vulnerability scan (`bin/brakeman`) against my changes.
- [x] run the test suite (`bin/rake spec`) and verified that all tests pass.
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] read, understand, and agree to the terms described in [CONTRIBUTING.md](https://github.com/deptofdefense/move.mil/blob/master/CONTRIBUTING.md).

## Summary of Changes

This is a very small change to entitlements data. The rank names in the entitlements are used in places where an **individual** user is asked for their rank - the entitlements page and the PPM estimator page. Therefore, the rank name should be singular, not plural. ("Civilian Employee" was already singular.)

## Testing

To verify the changes proposed in this pull request…

1. clone this repo,
1. git checkout `rank-singular`,
1. set up development dependencies according to [CONTRIBUTING.md](https://github.com/deptofdefense/move.mil/blob/master/CONTRIBUTING.md),
1. run `bin/rails db:setup`,
1. run `bin/rails server`, and
1. load up [http://localhost:3000](http://localhost:3000) in the Web browser of your choice.
