### PR TITLE
What To Expect: Loading / Moving Day - clear up confusion about signing in the remarks section

### DIFF
--- a/app/views/pages/moving-guide/conus.html.erb
+++ b/app/views/pages/moving-guide/conus.html.erb
@@ -126,7 +126,15 @@
 
       <p>During packing and loading, the transportation company will be creating an inventory of all your household items and will put stickers on all the boxes and larger items (couches, large appliances, etc.). On these inventory sheets, they will also be indicating whether or not there was any pre-existing damage to your household goods. If you disagree with their assessment make sure you annotate that on the inventory sheet!</p>
 
-      <p>After everything is loaded up on the truck, do a walkthrough with the driver to make sure everything is out of your residence and loaded up. This will ensure that nothing gets left behind. If possible, ask the driver for their phone number so you can reach them if needed. <strong>The last thing will be signing the inventory sheet… if you don't agree with something on that form make sure you annotate that BEFORE signing in the remarks section!</strong></p>
+      <p>
+        After everything is loaded up on the truck, do a walkthrough with the
+        driver to make sure everything is out of your residence and loaded up.
+        This will ensure that nothing gets left behind. If possible, ask the
+        driver for their phone number so you can reach them if needed.
+        <strong>The last thing will be signing the inventory sheet… if you
+        don't agree with something on that form make sure you annotate that in
+        the remarks section BEFORE signing!</strong>
+      </p>
     </div>
 
     <div id="on-the-road" class="article-section">


### PR DESCRIPTION
Addresses #390. 

## Checklist

I have…

- [x] run the application locally (`bin/rails server`) and verified that my changes behave as expected.
- [x] run static code analysis (`bin/rubocop`) and vulnerability scan (`bin/brakeman`) against my changes.
- [x] run the test suite (`bin/rake spec`) and verified that all tests pass.
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.
- [x] read, understand, and agree to the terms described in [CONTRIBUTING.md](https://github.com/deptofdefense/move.mil/blob/master/CONTRIBUTING.md).

## Summary of Changes

This pull request rearranges the words at the end of the "Loading / Moving Day" section in "What To Expect" for CONUS moves. It no longer implies signing in the remarks section.

## Testing

To verify the changes proposed in this pull request…

1. clone this repo,
1. git checkout `wte_remarks_signing`,
1. set up development dependencies according to [CONTRIBUTING.md](https://github.com/deptofdefense/move.mil/blob/master/CONTRIBUTING.md),
1. run `bin/rails server`, and
1. load up [http://localhost:3000](http://localhost:3000) in the Web browser of your choice.

## Screenshots

Before:

<img width="721" alt="screen shot 2018-03-23 at 12 07 05 pm" src="https://user-images.githubusercontent.com/26554826/37840439-7510119a-2e93-11e8-8b2f-f1b7056d96db.png">

After:

<img width="735" alt="screen shot 2018-03-23 at 12 06 45 pm" src="https://user-images.githubusercontent.com/26554826/37840446-78f53c86-2e93-11e8-8c61-fe740ff43027.png">
