### PR TITLE
DTR Part IV Appendix K-1 and the JTR both say that an O-4/W-4 w/ depe…

### DIFF
--- a/db/seeds/entitlements.yml
+++ b/db/seeds/entitlements.yml
@@ -82,7 +82,7 @@
 
 - rank: O-4/W-4
   total_weight_self: 14000
-  total_weight_self_plus_dependents: 17500
+  total_weight_self_plus_dependents: 17000
   pro_gear_weight: 2000
   pro_gear_weight_spouse: 500
 


### PR DESCRIPTION
It looks like we have a typo in our entitlements data. According to https://www.ustranscom.mil/dtr/part-iv/dtr_part_iv_app_k_1.pdf, An O-4 or W-4 with dependents has a weight entitlement of 17,000 lbs, not 17,500 lbs.