### PR TITLE
updated answer content in faq closes #394

### DIFF
--- a/lib/data/faqs.yml
+++ b/lib/data/faqs.yml
@@ -331,5 +331,5 @@
 
 - question: What type of surveys can I be expected to fill out?
   answer: |
-    <p>At the end of your move, it’s highly recommended that you take time to fill out the customer satisfaction survey at the end. This provides the property offices with direct feedback on your moving company. Be honest and leave comments – if they were a great mover we want to make sure they get the chance to work with members and their families in the future. If they were not so great… we want to make sure they don’t get any future opportunities to mess things up.</p>
+    <p>At the end of the your move, you are required to fill out the customer satisfaction survey. This provides the Personal Property offices with direct feedback on your moving company. Be honest and leave comments – if they were a great mover we want to make sure they get the chance to work with members and their families in the future. If they were not so great… we want to make sure they don’t receive future opportunities.</p>
   category: after-the-move


### PR DESCRIPTION
Thanks for submitting a pull request! Below are a few things you can do to help us more quickly review your changes.

## Checklist

I have…

- [x] run the application locally (`bin/rails server`) and verified that my changes behave as expected.
- [x] run static code analysis (`bin/rubocop`) and vulnerability scan (`bin/brakeman`) against my changes.
- [x] run the test suite (`bin/rake spec`) and verified that all tests pass.
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.
- [x] read, understand, and agree to the terms described in [CONTRIBUTING.md](https://github.com/deptofdefense/move.mil/blob/master/CONTRIBUTING.md).
- [x] added my name, email address, and copyright date to [CONTRIBUTORS.md](https://github.com/deptofdefense/move.mil/blob/master/CONTRIBUTORS.md).

## Summary of Changes

This pull request…

- updates the FAQ content in After the Move for What type of surveys...

## Testing

To verify the changes proposed in this pull request…

1. navigate to FAQs > After the Move > What type of surveys can I be expected to fill out?
2. click on the faq accordion to reveal the answer content, the new content should read,

"At the end of the your move, you are required to fill out the customer satisfaction survey. This provides the Personal Property offices with direct feedback on your moving company. Be honest and leave comments – if they were a great mover we want to make sure they get the chance to work with members and their families in the future. If they were not so great… we want to make sure they don’t receive future opportunities."

## Screenshots

before
<img width="1044" alt="screen shot 2018-04-02 at 3 30 26 pm" src="https://user-images.githubusercontent.com/37077057/38212748-e07e04f4-368c-11e8-8317-3bd2ca177ff8.png">

after
<img width="1009" alt="screen shot 2018-04-02 at 3 45 42 pm" src="https://user-images.githubusercontent.com/37077057/38212760-ec862902-368c-11e8-9243-34342651d07f.png">

