### PR TITLE
Numeric-only inputs

### DIFF
--- a/app/views/ppm_estimator/index.html.erb
+++ b/app/views/ppm_estimator/index.html.erb
@@ -55,11 +55,11 @@
       <div class="usa-grid-full grid-form-width">
         <div class="usa-width-one-half">
           <%= form.label :start, 'Origin ZIP Code' %>
-          <%= form.text_field :start, { id: :start, minlength: 5, maxlength: 5, inputmode: 'numeric', pattern: '\d{5}', required: true } %>
+          <%= form.number_field :start, { id: :start, minlength: 5, maxlength: 5, max: 99999, inputmode: 'numeric', pattern: '[0-9]*', required: true } %>
         </div>
         <div class="usa-width-one-half">
           <%= form.label :end, 'Destination ZIP Code' %>
-          <%= form.text_field :end, { id: :end, minlength: 5, maxlength: 5, inputmode: 'numeric', pattern: '\d{5}', required: true } %>
+          <%= form.number_field :end, { id: :end, minlength: 5, maxlength: 5, max: 99999, inputmode: 'numeric', pattern: '[0-9]*', required: true } %>
         </div>
       </div>
     </fieldset>
@@ -70,15 +70,15 @@
       <div class="usa-date-of-birth" id="date-section">
         <div class="ppm-form-group-month">
           <%= form.label :date_month, 'Month' %>
-          <%= form.number_field :date_month, { id: :date_month, class: 'usa-input-inline', 'aria-describedby' => 'dateHint', min: 1, max: 12, required: true } %>
+          <%= form.number_field :date_month, { id: :date_month, class: 'usa-input-inline', 'aria-describedby' => 'dateHint', min: 1, max: 12, inputmode: 'numeric', pattern: '[0-9]*', required: true } %>
         </div>
         <div class="ppm-form-group-day">
           <%= form.label :date_day, 'Day' %>
-          <%= form.number_field :date_day, { id: :date_day, class: 'usa-input-inline', 'aria-describedby' => 'dateHint', min: 1, max: 31, required: true } %>
+          <%= form.number_field :date_day, { id: :date_day, class: 'usa-input-inline', 'aria-describedby' => 'dateHint', min: 1, max: 31, inputmode: 'numeric', pattern: '[0-9]*', required: true } %>
         </div>
         <div class="ppm-form-group-year">
           <%= form.label :date_year, 'Year' %>
-          <%= form.number_field :date_year, { id: :date_year, class: 'usa-input-inline', 'aria-describedby' => 'dateHint', min: Date.today.year, required: true } %>
+          <%= form.number_field :date_year, { id: :date_year, class: 'usa-input-inline', 'aria-describedby' => 'dateHint', min: Date.today.year, max: 2099, inputmode: 'numeric', pattern: '[0-9]*', required: true } %>
         </div>
       </div>
     </fieldset>
@@ -96,21 +96,21 @@
       </p>
       <div id="weight-section">
         <%= form.label :weight, 'Estimated Household Goods Weight (lbs)' %>
-        <%= form.number_field :weight, { id: :weight, inputmode: 'numeric', required: true } %>
+        <%= form.number_field :weight, { id: :weight, inputmode: 'numeric', pattern: '[0-9]*', required: true } %>
         <p id="weight-allowance-text">
           Your weight allowance is up to <strong><span id="entitlement_weight"></span> lbs</strong>.
         </p>
       </div>
       <div id="progear-section">
         <%= form.label :weight_progear, 'Estimated Pro-Gear Weight (lbs)' %>
-        <%= form.number_field :weight_progear, { id: :weight_progear, inputmode: 'numeric', required: false } %>
+        <%= form.number_field :weight_progear, { id: :weight_progear, inputmode: 'numeric', pattern: '[0-9]*', required: false } %>
         <p id="progear-allowance-text">
           Your Pro-Gear allowance is up to <strong><span id="entitlement_progear"></span> lbs</strong>.
         </p>
       </div>
       <div id="progear-spouse-section" hidden>
         <%= form.label :weight_progear_spouse, "Estimated Spouse's Pro-Gear Weight (lbs)" %>
-        <%= form.number_field :weight_progear_spouse, { id: :weight_progear_spouse, inputmode: 'numeric', required: false } %>
+        <%= form.number_field :weight_progear_spouse, { id: :weight_progear_spouse, inputmode: 'numeric', pattern: '[0-9]*', required: false } %>
         <p id="progear-spouse-allowance-text">
           Your spouse's Pro-Gear allowance is up to <strong><span id="entitlement_progear_spouse"></span> lbs</strong>.
         </p>

--- a/app/views/weight_estimator/_household_goods.html.erb
+++ b/app/views/weight_estimator/_household_goods.html.erb
@@ -13,7 +13,7 @@
             <%= label_tag household_good.key, household_good.name %>
           </td>
           <td>
-            <%= text_field_tag household_good.key, nil, class: 'hhg-quantity-input', id: household_good.key, pattern: '\d+' %>
+            <%= number_field_tag household_good.key, nil, class: 'hhg-quantity-input', id: household_good.key, inputmode: 'numeric', pattern: '[0-9]*' %>
             <%= hidden_field_tag household_good.weight_key, household_good.weight, class: 'hhg-weight' %>
           </td>
         </tr>

--- a/app/views/weight_estimator/index.html.erb
+++ b/app/views/weight_estimator/index.html.erb
@@ -34,7 +34,7 @@
                     <%- 3.times do -%>
                       <tr>
                         <td><%= text_field_tag nil, nil, class: 'hhg-misc-input', placeholder: 'Item Description' %></td>
-                        <td><%= text_field_tag nil, nil, class: 'hhg-weight-input', pattern: '\d+', placeholder: 'lbs' %></td>
+                        <td><%= number_field_tag nil, nil, class: 'hhg-weight-input', inputmode: 'numeric', pattern: '[0-9]*', placeholder: 'lbs' %></td>
                       </tr>
                     <%- end -%>
                   </tbody>


### PR DESCRIPTION
Addresses #374.

## Checklist

I have…

- [x] run the application locally (`bin/rails server`) and verified that my changes behave as expected.
- [x] run static code analysis (`bin/rubocop`) and vulnerability scan (`bin/brakeman`) against my changes.
- [x] run the test suite (`bin/rake spec`) and verified that all tests pass.
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.
- [x] tested my changes in a modern desktop browser, Internet Explorer 11, and a modern mobile browser.
- [x] read, understand, and agree to the terms described in [CONTRIBUTING.md](https://github.com/deptofdefense/move.mil/blob/master/CONTRIBUTING.md).

## Summary of Changes

This pull request sets the apporpriate attributes on the PPM Estimator and Weight Estimator forms so that mobile browsers will get the numeric-only keyboard when entering quantities, ZIP codes, dates, and weights.

## Testing

To verify the changes proposed in this pull request…

1. clone this repo,
1. git checkout `numeric-only-inputs`,
1. set up development dependencies according to [CONTRIBUTING.md](https://github.com/deptofdefense/move.mil/blob/master/CONTRIBUTING.md),
1. run `bin/rails server`, and
1. load up [http://localhost:3000](http://localhost:3000) in the Web browser of your choice.

## Screenshots

<details><summary>PPM Estimator - zip code field - before (iOS Safari)</summary>

![img_2697c1814ece-1](https://user-images.githubusercontent.com/26554826/38832629-27f0515c-4191-11e8-9189-44a4fa1ff4ff.jpeg)

</details>

<details><summary>PPM Estimator - zip code field - after (iOS Safari)</summary>

![img_ddce3b3e48e1-1](https://user-images.githubusercontent.com/26554826/38832634-2d385a6a-4191-11e8-821f-17fce955ca90.jpeg)

</details>

<details><summary>Weight Estimator - quantity field - before (iOS Safari)</summary>

![img_d8767e3d230a-1](https://user-images.githubusercontent.com/26554826/38832638-32146902-4191-11e8-8af8-b9d301d9ba6a.jpeg)

</details>

<details><summary>Weight Estimator - quantity field - after (iOS Safari)</summary>

![img_bd6a817cadd0-1](https://user-images.githubusercontent.com/26554826/38832642-36778a9c-4191-11e8-8285-20b7b62ff57c.jpeg)

</details>
