### PR TITLE
PPM Estimator: Remove branch of service field, as all services now offer 60% advance

### DIFF
--- a/app/assets/stylesheets/components/_ppm-estimator.scss
+++ b/app/assets/stylesheets/components/_ppm-estimator.scss
@@ -99,7 +99,7 @@
   align-items: stretch;
   display: flex;
   flex-wrap: wrap;
-  justify-content: space-around;
+  justify-content: space-between;
   margin-top: 0.76rem;
 }
 
@@ -107,9 +107,12 @@
   white-space: nowrap;
 }
 
+.ppm-estimate-your-details {
+  flex: 0 0;
+}
+
 .ppm-estimate-rank {
   margin-left: 0.8rem;
-  min-width: 28rem;
   text-align: right;
 }
 

--- a/app/controllers/ppm_estimator_controller.rb
+++ b/app/controllers/ppm_estimator_controller.rb
@@ -1,6 +1,6 @@
 class PpmEstimatorController < ApplicationController
   def index
-    return lookups unless request.xhr?
+    return entitlements unless request.xhr?
     return render plain: '', status: :not_found unless ppm_estimator.valid?
 
     render partial: 'ppm_estimator/estimate_table', locals: { inputs: params }
@@ -8,18 +8,8 @@ class PpmEstimatorController < ApplicationController
 
   private
 
-  def branches
-    @branches ||= BranchOfService.select(:name, :slug)
-  end
-
   def entitlements
     @entitlements ||= Entitlement.all
-  end
-
-  # populate some of the drop downs in the form
-  def lookups
-    entitlements
-    branches
   end
 
   def ppm_estimator

--- a/app/models/ppm_estimator.rb
+++ b/app/models/ppm_estimator.rb
@@ -5,7 +5,7 @@ class PpmEstimator
   end
 
   def advance_percentage
-    estimator_params[:branch] == 'marine-corps' ? 50 : 60
+    60
   end
 
   def date
@@ -18,10 +18,6 @@ class PpmEstimator
 
   def rank_name
     Entitlement.select(:rank).find_by(slug: estimator_params[:rank]).rank
-  end
-
-  def branch_name
-    BranchOfService.select(:name).find_by(slug: estimator_params[:branch]).name
   end
 
   def weight_self
@@ -79,7 +75,7 @@ class PpmEstimator
 
   def valid?
     # weight_progear and weight_progear_spouse can be empty, will be regarded as 0
-    required_params = %w[rank branch dependents start end date_year date_month date_day weight]
+    required_params = %w[rank dependents start end date_year date_month date_day weight]
 
     estimator_params.permitted? &&
       (required_params - estimator_params.keys).empty? &&
@@ -90,7 +86,7 @@ class PpmEstimator
   private
 
   def estimator_params
-    @estimator_params ||= @params.permit(:rank, :branch, :dependents, :start, :end, :date_year, :date_month, :date_day, :weight, :weight_progear, :weight_progear_spouse)
+    @estimator_params ||= @params.permit(:rank, :dependents, :start, :end, :date_year, :date_month, :date_day, :weight, :weight_progear, :weight_progear_spouse)
   end
 
   # returns the full_weight divided by 100, AKA the hundredweight (centiweight?)

--- a/app/views/ppm_estimator/_estimate_table.html.erb
+++ b/app/views/ppm_estimator/_estimate_table.html.erb
@@ -17,7 +17,7 @@
   %>
 
   <div class="ppm-estimate-details">
-    <div class="ppm-estimate-table-cell nowrap">
+    <div class="ppm-estimate-your-details nowrap">
       Your Details:
     </div>
     <div class="ppm-estimate-table-cell ppm-estimate-data ppm-estimate-rank">

--- a/app/views/ppm_estimator/_estimate_table.html.erb
+++ b/app/views/ppm_estimator/_estimate_table.html.erb
@@ -20,9 +20,6 @@
     <div class="ppm-estimate-table-cell nowrap">
       Your Details:
     </div>
-    <div class="ppm-estimate-table-cell ppm-estimate-data nowrap">
-      <%= @ppm_estimator.branch_name %>
-    </div>
     <div class="ppm-estimate-table-cell ppm-estimate-data ppm-estimate-rank">
       <%= @ppm_estimator.rank_name %>
       <%- if @ppm_estimator.dependents? %>

--- a/app/views/ppm_estimator/index.html.erb
+++ b/app/views/ppm_estimator/index.html.erb
@@ -23,15 +23,11 @@
 
   <%= form_with url: ppm_estimator_path, class: 'ppm-form', id: 'ppm-estimate-form', method: 'get', skip_enforcing_utf8: true do |form| %>
     <fieldset>
-      <legend>What is your rank and branch of service?</legend>
+      <legend>What is your rank?</legend>
       <div class="usa-grid-full grid-form-width">
         <div class="usa-width-one-half">
           <%= form.label :rank, 'Rank' %>
           <%= form.select :rank, options_from_collection_for_select(@entitlements, :slug, :rank), { prompt: '- Select -' }, { id: :rank, required: true } %>
-        </div>
-        <div class="usa-width-one-half">
-          <%= form.label :branch, 'Branch of Service' %>
-          <%= form.select :branch, options_from_collection_for_select(@branches, :slug, :name), { prompt: '- Select -' }, { id: :branch, required: true } %>
         </div>
       </div>
     </fieldset>
@@ -143,7 +139,7 @@
   <div class="ppm-footer" id="ppm-footer">
     <strong>Note:</strong> This tool only provides an estimate of what you
     might receive if you decide to do a personally procured move.
-    <strong>Your actual incentive will be calculated using the 
+    <strong>Your actual incentive will be calculated using the
     current rates on the day you schedule your move in DPS.</strong> Rates
     vary based on transporter availability, selected move date (Peak vs.
     Non-Peak Season), distance traveled, and the actual weight of the shipment.

--- a/app/views/ppm_estimator/index.html.erb
+++ b/app/views/ppm_estimator/index.html.erb
@@ -24,12 +24,8 @@
   <%= form_with url: ppm_estimator_path, class: 'ppm-form', id: 'ppm-estimate-form', method: 'get', skip_enforcing_utf8: true do |form| %>
     <fieldset>
       <legend>What is your rank?</legend>
-      <div class="usa-grid-full grid-form-width">
-        <div class="usa-width-one-half">
-          <%= form.label :rank, 'Rank' %>
-          <%= form.select :rank, options_from_collection_for_select(@entitlements, :slug, :rank), { prompt: '- Select -' }, { id: :rank, required: true } %>
-        </div>
-      </div>
+      <%= form.label :rank, 'Rank' %>
+      <%= form.select :rank, options_from_collection_for_select(@entitlements, :slug, :rank), { prompt: '- Select -' }, { id: :rank, required: true } %>
     </fieldset>
 
     <fieldset>

--- a/spec/requests/ppm_estimator_spec.rb
+++ b/spec/requests/ppm_estimator_spec.rb
@@ -3,9 +3,6 @@ RSpec.describe PpmEstimatorController, type: :request do
     let!(:e1) { create(:entitlement, rank: 'E-1', total_weight_self: 5_000, total_weight_self_plus_dependents: 8_000, pro_gear_weight: 2_000, pro_gear_weight_spouse: 500) }
     let!(:o6) { create(:entitlement, rank: 'O-6', total_weight_self: 18_000, total_weight_self_plus_dependents: 18_000, pro_gear_weight: 2_000, pro_gear_weight_spouse: 500) }
 
-    let!(:army) { create(:branch_of_service, name: 'Army') }
-    let!(:marine_corps) { create(:branch_of_service, name: 'Marine Corps') }
-
     context 'when navigating to the page' do
       before do
         get '/resources/ppm-estimator'
@@ -22,11 +19,6 @@ RSpec.describe PpmEstimatorController, type: :request do
       it 'populates the rank select input' do
         # count includes the blank or prompt option
         assert_select '#rank option', count: 3
-      end
-
-      it 'populates the branch select input' do
-        # count includes the blank or prompt option
-        assert_select '#branch option', count: 3
       end
     end
 
@@ -51,7 +43,7 @@ RSpec.describe PpmEstimatorController, type: :request do
 
       context 'and sending valid params' do
         before do
-          get '/resources/ppm-estimator', params: { rank: 'e-1', branch: 'army', dependents: 'yes', start: '90210', end: '20001', date_year: '2018', date_month: '1', date_day: '31', weight: '1000' }, xhr: true
+          get '/resources/ppm-estimator', params: { rank: 'e-1', dependents: 'yes', start: '90210', end: '20001', date_year: '2018', date_month: '1', date_day: '31', weight: '1000' }, xhr: true
         end
 
         it 'shows a PPM estimate' do
@@ -67,7 +59,7 @@ RSpec.describe PpmEstimatorController, type: :request do
         let!(:la_lv_top_discount) { create(:top_tsp_by_channel_linehaul_discount, orig: 'US88', dest: 'REGION 2', tdl: Range.new(Date.parse('2017-10-01'), Date.parse('2017-12-31')), discount: 67.0) }
 
         before do
-          get '/resources/ppm-estimator', params: { rank: 'e-1', branch: 'army', dependents: 'yes', start: '90210', end: '88901', date_year: '2018', date_month: '1', date_day: '31', weight: '1000' }, xhr: true
+          get '/resources/ppm-estimator', params: { rank: 'e-1', dependents: 'yes', start: '90210', end: '88901', date_year: '2018', date_month: '1', date_day: '31', weight: '1000' }, xhr: true
         end
 
         it 'shows a PPM estimate' do
@@ -84,7 +76,7 @@ RSpec.describe PpmEstimatorController, type: :request do
         let!(:ocala_dc_top_discount) { create(:top_tsp_by_channel_linehaul_discount, orig: 'US49', dest: 'REGION 10', tdl: Range.new(Date.parse('2017-10-01'), Date.parse('2017-12-31')), discount: 67.0) }
 
         before do
-          get '/resources/ppm-estimator', params: { rank: 'e-1', branch: 'army', dependents: 'yes', start: '34470', end: '20001', date_year: '2018', date_month: '1', date_day: '31', weight: '1000' }, xhr: true
+          get '/resources/ppm-estimator', params: { rank: 'e-1', dependents: 'yes', start: '34470', end: '20001', date_year: '2018', date_month: '1', date_day: '31', weight: '1000' }, xhr: true
         end
 
         it 'shows a PPM estimate' do
@@ -93,8 +85,8 @@ RSpec.describe PpmEstimatorController, type: :request do
       end
 
       context 'and a required parameter is missing' do
-        [:rank, :branch, :dependents, :start, :end, :date, :weight].each do |param|
-          let(:required_params) { { rank: 'e-1', branch: 'army', dependents: 'yes', start: '90210', end: '20001', date: '2017-12-31', weight: '1000' } }
+        [:rank, :dependents, :start, :end, :date, :weight].each do |param|
+          let(:required_params) { { rank: 'e-1', dependents: 'yes', start: '90210', end: '20001', date: '2017-12-31', weight: '1000' } }
           before do
             missing_a_param = required_params.deep_dup
             missing_a_param.delete(param)
@@ -108,7 +100,7 @@ RSpec.describe PpmEstimatorController, type: :request do
       end
 
       context 'and sending an invalid date' do
-        let(:bad_date_params) { { rank: 'e-1', branch: 'army', dependents: 'yes', start: '90210', end: '20001', date: '2017-02-31', weight: '1000' } }
+        let(:bad_date_params) { { rank: 'e-1', dependents: 'yes', start: '90210', end: '20001', date: '2017-02-31', weight: '1000' } }
 
         before do
           get '/resources/ppm-estimator', params: :bad_date_params, xhr: true


### PR DESCRIPTION
Addresses #415.

## Checklist

I have…

- [x] run the application locally (`bin/rails server`) and verified that my changes behave as expected.
- [x] run static code analysis (`bin/rubocop`) and vulnerability scan (`bin/brakeman`) against my changes.
- [x] run the test suite (`bin/rake spec`) and verified that all tests pass.
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [ ] attached screenshots illustrating relevant behavior before and after my changes.
- [x] tested my changes in a modern desktop browser, Internet Explorer 11, and a modern mobile browser.
- [x] read, understand, and agree to the terms described in [CONTRIBUTING.md](https://github.com/deptofdefense/move.mil/blob/master/CONTRIBUTING.md).

## Summary of Changes

This pull request removes the branch of service input field from the PPM Estimator, as all services now offer up to a 60% advance. It also adjusts the formatting of the output slightly so that the "Your Details:" and rank strings fit on the same line more often.

## Testing

To verify the changes proposed in this pull request…

1. clone this repo,
1. git checkout `common-advance-60`,
1. set up development dependencies according to [CONTRIBUTING.md](https://github.com/deptofdefense/move.mil/blob/master/CONTRIBUTING.md),
1. run `bin/rails server`, and
1. load up [http://localhost:3000](http://localhost:3000) in the Web browser of your choice.

## Screenshots
