### PR TITLE
Fix numeric input UI bugs introduced in PR #417

### DIFF
--- a/app/assets/stylesheets/elements/_inputs.scss
+++ b/app/assets/stylesheets/elements/_inputs.scss
@@ -1,0 +1,5 @@
+input[type=number]::-webkit-inner-spin-button,
+input[type=number]::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}

--- a/app/views/ppm_estimator/index.html.erb
+++ b/app/views/ppm_estimator/index.html.erb
@@ -96,21 +96,21 @@
       </p>
       <div id="weight-section">
         <%= form.label :weight, 'Estimated Household Goods Weight (lbs)' %>
-        <%= form.number_field :weight, { id: :weight, inputmode: 'numeric', pattern: '[0-9]*', required: true } %>
+        <%= form.number_field :weight, { id: :weight, inputmode: 'numeric', min: 0, pattern: '[0-9]*', required: true } %>
         <p id="weight-allowance-text">
           Your weight allowance is up to <strong><span id="entitlement_weight"></span> lbs</strong>.
         </p>
       </div>
       <div id="progear-section">
         <%= form.label :weight_progear, 'Estimated Pro-Gear Weight (lbs)' %>
-        <%= form.number_field :weight_progear, { id: :weight_progear, inputmode: 'numeric', pattern: '[0-9]*', required: false } %>
+        <%= form.number_field :weight_progear, { id: :weight_progear, inputmode: 'numeric', min: 0, pattern: '[0-9]*', required: false } %>
         <p id="progear-allowance-text">
           Your Pro-Gear allowance is up to <strong><span id="entitlement_progear"></span> lbs</strong>.
         </p>
       </div>
       <div id="progear-spouse-section" hidden>
         <%= form.label :weight_progear_spouse, "Estimated Spouse's Pro-Gear Weight (lbs)" %>
-        <%= form.number_field :weight_progear_spouse, { id: :weight_progear_spouse, inputmode: 'numeric', pattern: '[0-9]*', required: false } %>
+        <%= form.number_field :weight_progear_spouse, { id: :weight_progear_spouse, inputmode: 'numeric', min: 0, pattern: '[0-9]*', required: false } %>
         <p id="progear-spouse-allowance-text">
           Your spouse's Pro-Gear allowance is up to <strong><span id="entitlement_progear_spouse"></span> lbs</strong>.
         </p>

--- a/app/views/weight_estimator/_household_goods.html.erb
+++ b/app/views/weight_estimator/_household_goods.html.erb
@@ -13,7 +13,7 @@
             <%= label_tag household_good.key, household_good.name %>
           </td>
           <td>
-            <%= number_field_tag household_good.key, nil, class: 'hhg-quantity-input', id: household_good.key, inputmode: 'numeric', pattern: '[0-9]*' %>
+            <%= number_field_tag household_good.key, nil, class: 'hhg-quantity-input', id: household_good.key, inputmode: 'numeric', min: 0, pattern: '[0-9]*' %>
             <%= hidden_field_tag household_good.weight_key, household_good.weight, class: 'hhg-weight' %>
           </td>
         </tr>

--- a/app/views/weight_estimator/index.html.erb
+++ b/app/views/weight_estimator/index.html.erb
@@ -34,7 +34,7 @@
                     <%- 3.times do -%>
                       <tr>
                         <td><%= text_field_tag nil, nil, class: 'hhg-misc-input', placeholder: 'Item Description' %></td>
-                        <td><%= number_field_tag nil, nil, class: 'hhg-weight-input', inputmode: 'numeric', pattern: '[0-9]*', placeholder: 'lbs' %></td>
+                        <td><%= number_field_tag nil, nil, class: 'hhg-weight-input', inputmode: 'numeric', min: 0, pattern: '[0-9]*', placeholder: 'lbs' %></td>
                       </tr>
                     <%- end -%>
                   </tbody>


### PR DESCRIPTION
Thanks for submitting a pull request! Below are a few things you can do to help us more quickly review your changes.

## Checklist

I have…

- [x] run the application locally (`bin/rails server`) and verified that my changes behave as expected.
- [x] run static code analysis (`bin/rubocop`) and vulnerability scan (`bin/brakeman`) against my changes.
- [x] run the test suite (`bin/rake spec`) and verified that all tests pass.
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.

## Summary of Changes

This pull request resolves several small UI bugs introduced by #417. See screenshots below for some examples.

1. Numeric input fields in WebKit browsers displayed number spinners which (on the weight estimator) would overlay the user's input value.
2. Numeric input fields lacked a `min="0"` which would (on the front-end anyway) allow users to spin the input below zero.

The changes here update numeric inputs on the [Weight Estimator](https://www.move.mil/resources/weight-estimator) and on the [PPM Estimator](https://www.move.mil/resources/ppm-estimator).

## Testing

To verify the changes proposed in this pull request…

1. clone this repo,
1. `git checkout fix-numeric-input-ui-bugs`,
1. set up development dependencies according to `CONTRIBUTING.md`,
1. run `bin/rails server`,
1. load up http://localhost:3000/resources/weight-estimator and note that spinners no longer appear in numeric fields.

## Screenshots

### Before

<img width="455" alt="before" src="https://user-images.githubusercontent.com/27780860/38950022-3b431ef6-4312-11e8-904a-28ce26d3ed40.png">

### After

<img width="451" alt="after" src="https://user-images.githubusercontent.com/27780860/38950027-3e39cede-4312-11e8-914d-4638b9bd9d55.png">